### PR TITLE
ff4j-aop is only able to proxy the first class (ordered by qualified name) matching an interface with a @Flip method.

### DIFF
--- a/ff4j-aop/src/main/java/org/ff4j/aop/FeatureAutoProxy.java
+++ b/ff4j-aop/src/main/java/org/ff4j/aop/FeatureAutoProxy.java
@@ -1,8 +1,8 @@
 package org.ff4j.aop;
 
 import java.lang.reflect.Method;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.springframework.aop.TargetSource;
 import org.springframework.aop.framework.autoproxy.AbstractAutoProxyCreator;
@@ -21,7 +21,7 @@ public class FeatureAutoProxy extends AbstractAutoProxyCreator implements Initia
 	private static final long serialVersionUID = -364406999854610869L;
 	
 	/** Processed Interfaces. */
-	private Set < String > processedInterface = new HashSet<String>();
+	private Map<String, Boolean> processedInterface = new HashMap<String, Boolean>();
 	
 	/** {@inheritDoc} */
 	public void afterPropertiesSet() throws Exception {
@@ -36,12 +36,20 @@ public class FeatureAutoProxy extends AbstractAutoProxyCreator implements Initia
 			for (Class<?> currentInterface : beanClass.getInterfaces()) {
 				String currentInterfaceName = currentInterface.getCanonicalName();
 				
-				if (!currentInterfaceName.startsWith("java.") && !processedInterface.contains(currentInterfaceName)) {
-					processedInterface.add(currentInterfaceName);
-					for (Method method : currentInterface.getDeclaredMethods()) {
-						if (method.isAnnotationPresent(Flip.class)) {
+				if (!currentInterfaceName.startsWith("java.")) {
+					Boolean isInterfaceFlipped = processedInterface.get(currentInterfaceName);
+					if(isInterfaceFlipped != null) {
+						if(isInterfaceFlipped){
 							return PROXY_WITHOUT_ADDITIONAL_INTERCEPTORS;
 						}
+					} else {
+						for (Method method : currentInterface.getDeclaredMethods()) {
+							if (method.isAnnotationPresent(Flip.class)) {
+								processedInterface.put(currentInterfaceName, true);
+								return PROXY_WITHOUT_ADDITIONAL_INTERCEPTORS;
+							}
+						}
+						processedInterface.put(currentInterfaceName, false);
 					}
 				}
 			}
@@ -50,8 +58,3 @@ public class FeatureAutoProxy extends AbstractAutoProxyCreator implements Initia
 	}
 	
 }
-
-	
-
-	
-

--- a/ff4j-aop/src/test/java/org/ff4j/aop/FeatureFlipperTest.java
+++ b/ff4j-aop/src/test/java/org/ff4j/aop/FeatureFlipperTest.java
@@ -3,13 +3,14 @@ package org.ff4j.aop;
 import junit.framework.Assert;
 
 import org.ff4j.FF4j;
+import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("classpath:applicationContext-ff4j-aop-test.xml")
@@ -19,12 +20,51 @@ public class FeatureFlipperTest {
 	@Qualifier("greeting.english")
 	private GreetingService greeting;
 
-	@Test
-	public void testAnnotatedFlipping() {
+	@Autowired
+	@Qualifier("goodbye.french")
+	private GoodbyeService goodbye;
+
+	@BeforeClass
+	public static void createFeatures() {
 		FF4j.createFeature("language-french");
+		FF4j.createFeature("language-english");
+	}
+
+	@After
+	public void disableFeatures() {
+		FF4j.disableFeature("language-french");
+		FF4j.disableFeature("language-english");
+	}
+
+	@Test
+	public void testAnnotatedFlipping_with_alterBean() {
 		Assert.assertTrue(greeting.sayHello("CLU").startsWith("Hello"));
-		
+
 		FF4j.enableFeature("language-french");
-		//Assert.assertTrue("Service did not flipped", greeting.sayHello("CLU").startsWith("Bonjour"));
+		Assert.assertTrue("Service did not flipped", greeting.sayHello("CLU").startsWith("Bonjour"));
+	}
+
+	@Test
+	public void testAnnotatedFlipping_with_alterClazz() {
+		Assert.assertTrue(greeting.sayHelloWithClass("CLU").startsWith("Hi"));
+
+		FF4j.enableFeature("language-french");
+		Assert.assertTrue("Service did not flipped", greeting.sayHelloWithClass("CLU").startsWith("Salut"));
+	}
+
+	@Test
+	public void testAnnotatedFlipping_if_qualified_implementation_is_not_the_first_class_qualified_name_in_natural_ordering() {
+		Assert.assertTrue(goodbye.sayGoodbye("CLU").startsWith("Au revoir"));
+
+		FF4j.enableFeature("language-english");
+		Assert.assertTrue("Service did not flipped", goodbye.sayGoodbye("CLU").startsWith("Goodbye"));
+	}
+
+	@Test
+	public void testAnnotatedFlipping_with_alterClazz_if_qualified_implementation_is_not_the_first_class_qualified_name_in_natural_ordering() {
+		Assert.assertTrue(goodbye.sayGoodbyeWithClass("CLU").startsWith("A plus"));
+
+		FF4j.enableFeature("language-english");
+		Assert.assertTrue("Service did not flipped", goodbye.sayGoodbyeWithClass("CLU").startsWith("See you"));
 	}
 }

--- a/ff4j-aop/src/test/java/org/ff4j/aop/GoodbyeService.java
+++ b/ff4j-aop/src/test/java/org/ff4j/aop/GoodbyeService.java
@@ -1,0 +1,11 @@
+package org.ff4j.aop;
+
+public interface GoodbyeService {
+
+	@Flip(name = "language-english", alterBean = "goodbye.english")
+	String sayGoodbye(String name);
+
+	@Flip(name = "language-english", alterClazz = GoodbyeServiceEnglishImpl.class)
+	String sayGoodbyeWithClass(String name);
+
+}

--- a/ff4j-aop/src/test/java/org/ff4j/aop/GoodbyeServiceEnglishImpl.java
+++ b/ff4j-aop/src/test/java/org/ff4j/aop/GoodbyeServiceEnglishImpl.java
@@ -1,0 +1,17 @@
+package org.ff4j.aop;
+
+import org.springframework.stereotype.Component;
+
+@Component("goodbye.english")
+public class GoodbyeServiceEnglishImpl implements GoodbyeService {
+
+	@Override
+	public String sayGoodbye(String name) {
+		return "Goodbye " + name;
+	}
+
+	@Override
+	public String sayGoodbyeWithClass(String name) {
+		return "See you " + name;
+	}
+}

--- a/ff4j-aop/src/test/java/org/ff4j/aop/GoodbyeServiceFrenchImpl.java
+++ b/ff4j-aop/src/test/java/org/ff4j/aop/GoodbyeServiceFrenchImpl.java
@@ -1,0 +1,17 @@
+package org.ff4j.aop;
+
+import org.springframework.stereotype.Component;
+
+@Component("goodbye.french")
+public class GoodbyeServiceFrenchImpl implements GoodbyeService {
+
+	@Override
+	public String sayGoodbye(String name) {
+		return "Au revoir " + name;
+	}
+
+	@Override
+	public String sayGoodbyeWithClass(String name) {
+		return "A plus " + name;
+	}
+}

--- a/ff4j-aop/src/test/java/org/ff4j/aop/GreetingService.java
+++ b/ff4j-aop/src/test/java/org/ff4j/aop/GreetingService.java
@@ -1,8 +1,11 @@
 package org.ff4j.aop;
 
 public interface GreetingService {
-	
-	@Flip(name="language-french", alterBean="greeting.french")
+
+	@Flip(name = "language-french", alterBean = "greeting.french")
 	String sayHello(String name);
-	
+
+	@Flip(name = "language-french", alterClazz = GreetingServiceFrenchImpl.class)
+	String sayHelloWithClass(String name);
+
 }

--- a/ff4j-aop/src/test/java/org/ff4j/aop/GreetingServiceEnglishImpl.java
+++ b/ff4j-aop/src/test/java/org/ff4j/aop/GreetingServiceEnglishImpl.java
@@ -9,5 +9,9 @@ public class GreetingServiceEnglishImpl implements GreetingService {
 		return "Hello " + name;
 	}
 
-}
+	@Override
+	public String sayHelloWithClass(String name) {
+		return "Hi " + name;
+	}
 
+}

--- a/ff4j-aop/src/test/java/org/ff4j/aop/GreetingServiceFrenchImpl.java
+++ b/ff4j-aop/src/test/java/org/ff4j/aop/GreetingServiceFrenchImpl.java
@@ -9,4 +9,9 @@ public class GreetingServiceFrenchImpl implements GreetingService {
 		return "Bonjour " + name;
 	}
 
+	@Override
+	public String sayHelloWithClass(String name) {
+		return "Salut " + name;
+	}
+
 }


### PR DESCRIPTION
Hi Cédrick,

Thanks for FF4J, I am playing with it and it looks great !

It takes me some time to understand why this example was not working :

``` java
public interface GreetingService {
   @Flip(name="language-english", alterBean="greeting.english")
   String sayHello(String name);
}

@Component("greeting.english")
public class GreetingServiceEnglishImpl implements GreetingService {
    public String sayHello(String name) {
      return "Hello " + name;
    }
}

@Component("greeting.french")
public class GreetingServiceFrenchImpl implements GreetingService {
    public String sayHello(String name) {
        return "Bonjour " + name;
    }
}
```

With autowired :

``` java
    @Autowired
    @Qualifier("greeting.french")
    private GreetingService greeting;
```

AOP only proxy the first implementation (ordered by qualified name), so "greeting.french" bean was not proxied and not feature flipping was available.
An obvious workaround is to rename the default implementation to be the first found but quite ugly... :)

This commit will proxy each implementation of an interface contaning a @Flip method.

Regards,
Gautier
