### PR TITLE
Unit test isolation

### DIFF
--- a/ff4j-cache-ehcache/src/test/java/org/ff4j/cache/EhCacheCacheProviderTest.java
+++ b/ff4j-cache-ehcache/src/test/java/org/ff4j/cache/EhCacheCacheProviderTest.java
@@ -20,16 +20,26 @@ package org.ff4j.cache;
  * #L%
  */
 
+import net.sf.ehcache.CacheManager;
 import org.ff4j.core.FeatureStore;
 import org.ff4j.store.InMemoryFeatureStore;
 import org.ff4j.test.AbstractStoreTest;
+import org.junit.After;
 
 public class EhCacheCacheProviderTest extends AbstractStoreTest {
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public FeatureStore initStore() {
         return new FeatureStoreCacheProxy(new InMemoryFeatureStore("test-ehcacheProvider.xml"), new FeatureCacheProviderEhCache());
+    }
+
+    @After
+    public void tearDown() {
+        CacheManager cacheManager = CacheManager.create();
+        cacheManager.removalAll();
     }
 
 }

--- a/ff4j-core/pom.xml
+++ b/ff4j-core/pom.xml
@@ -58,6 +58,18 @@
 			<artifactId>spring-jdbc</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib</artifactId>
+            <scope>compile</scope>
+        </dependency>
 		
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/ff4j-core/src/main/java/org/ff4j/test/AbstractStoreTest.java
+++ b/ff4j-core/src/main/java/org/ff4j/test/AbstractStoreTest.java
@@ -35,6 +35,7 @@ import org.ff4j.exception.FeatureNotFoundException;
 import org.ff4j.strategy.PonderationFlipStrategy;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * For different store.
@@ -98,6 +99,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test
+    @Transactional
     public void testStoreHasBeenInitialized() throws Exception {
         assertFf4j.assertFeatureNumber(EXPECTED_FEATURES_NUMBERS);
         assertFf4j.assertFlipped(FEATURE_FIRST);
@@ -110,6 +112,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test
+    @Transactional
     public void testReadllFeatures() {
         assertFf4j.assertFeatureNumber(EXPECTED_FEATURES_NUMBERS);
         Map<String, Feature> features = testedStore.readAll();
@@ -124,6 +127,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test
+    @Transactional
     public void testReadFullFeature() {
         Feature f = testedStore.read(FEATURE_FORTH);
         Assert.assertEquals(f.getUid(), FEATURE_FORTH);
@@ -140,6 +144,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test(expected = FeatureNotFoundException.class)
+    @Transactional
     public void testFlipWithInvalidNameNotFoundException() {
         ff4j.isFlipped("this_featureName_does_not_exist");
     }
@@ -151,6 +156,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test(expected = FeatureNotFoundException.class)
+    @Transactional
     public void testEnableNotFoundException() {
         ff4j.enable(FEATURE_DUMMY);
     }
@@ -162,6 +168,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test(expected = FeatureNotFoundException.class)
+    @Transactional
     public void testDisableNotFoundException() {
         ff4j.disable(FEATURE_DUMMY);
     }
@@ -173,6 +180,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test
+    @Transactional
     public void testEnableFeature() {
         ff4j.enable(FEATURE_FIRST);
         assertFf4j.assertFlipped(FEATURE_FIRST);
@@ -185,6 +193,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test
+    @Transactional
     public void testDisableFeature() {
         ff4j.disable(FEATURE_FIRST);
         assertFf4j.assertNotFlipped(FEATURE_FIRST);
@@ -197,6 +206,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test
+    @Transactional
     public void testAddFeature() throws Exception {
         Set<String> rights = new HashSet<String>(Arrays.asList(new String[] {ROLE_USER}));
         Feature fp = new Feature(FEATURE_NEW, true, "description", TESTING_GROUP, rights);
@@ -215,6 +225,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test(expected = FeatureAlreadyExistException.class)
+    @Transactional
     public void testAddFeatureAlreadyExis() throws Exception {
         // Create Once
         Feature fp = new Feature(FEATURE_NEW, true, "description2");
@@ -232,6 +243,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test
+    @Transactional
     public void testDeleteFeature() throws Exception {
         Set<String> rights = new HashSet<String>(Arrays.asList(new String[] {ROLE_USER}));
         Feature fp2 = new Feature("TO_BE_DELETED", true, TESTING_GROUP, "description4", rights);
@@ -251,6 +263,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test(expected = FeatureNotFoundException.class)
+    @Transactional
     public void testDeteleFeatureDoesnotExistReturnError() throws Exception {
         testedStore.delete("does-not-exist");
     }
@@ -262,6 +275,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test
+    @Transactional
     public void testGrantRoleToFeatureRoleDoesNotExist() throws Exception {
         testedStore.grantRoleOnFeature(FEATURE_FIRST, "role-does-not-exit1");
         assertFf4j.assertHasRole(FEATURE_FIRST, "role-does-not-exit1");
@@ -274,6 +288,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test(expected = FeatureNotFoundException.class)
+    @Transactional
     public void testGrantRoleToFeatureFeatureDoesNotExist() throws Exception {
         testedStore.grantRoleOnFeature("blablabla", "role-does-not-exit");
     }
@@ -285,6 +300,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test
+    @Transactional
     public void testDeleteRoleToFeature() throws Exception {
         testedStore.removeRoleFromFeature(FEATURE_FIRST, ROLE_USER);
         assertFf4j.assertDoesntHaveRole(FEATURE_FIRST, ROLE_USER);
@@ -297,6 +313,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test(expected = FeatureNotFoundException.class)
+    @Transactional
     public void testDeleteRoleFeatureDoesNotExit() {
         testedStore.removeRoleFromFeature("blabla", ROLE_USER);
     }
@@ -308,6 +325,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test
+    @Transactional
     public void testUpdateFeatureCoreData() throws Exception {
         Feature fpBis = new Feature(FEATURE_FIRST, false, "desca2");
         fpBis.setFlippingStrategy(new PonderationFlipStrategy(0.12));
@@ -323,6 +341,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test
+    @Transactional
     public void testUpdateFeatureMoreAutorisation() throws Exception {
         Set<String> rights2 = new HashSet<String>(Arrays.asList(new String[] {ROLE_USER,"X"}));
         Feature fpBis = new Feature(FEATURE_FIRST, false, TESTING_GROUP, "desco2", rights2);
@@ -338,6 +357,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test
+    @Transactional
     public void testUpdateFlipLessAutorisation() {
         Feature fpBis = new Feature(FEATURE_FIRST, false, null);
         testedStore.update(fpBis);
@@ -351,6 +371,7 @@ public abstract class AbstractStoreTest {
      *             error during test
      */
     @Test
+    @Transactional
     public void testUpdateFlipMoreAutorisationNotExistReturnError() {
         Set<String> rights2 = new HashSet<String>(Arrays.asList(new String[] {ROLE_USER,"ROLE_ADMIN"}));
         Feature fpBis = new Feature(FEATURE_FIRST, false, TESTING_GROUP, "desci2", rights2);

--- a/ff4j-store-jdbc/src/test/java/org/ff4j/test/store/JdbcFeatureStoreSpring2Test.java
+++ b/ff4j-store-jdbc/src/test/java/org/ff4j/test/store/JdbcFeatureStoreSpring2Test.java
@@ -14,9 +14,17 @@ package org.ff4j.test.store;
 import org.ff4j.FF4j;
 import org.ff4j.core.FeatureStore;
 import org.ff4j.test.AbstractStoreTest;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("classpath:*applicationContext-jdbc-test.xml")
 public class JdbcFeatureStoreSpring2Test extends AbstractStoreTest {
+
+    @Autowired
+    private FF4j ff4j;
 
     private static FeatureStore store = null;
 
@@ -24,8 +32,7 @@ public class JdbcFeatureStoreSpring2Test extends AbstractStoreTest {
     protected FeatureStore initStore() {
         if (store == null) {
             System.out.println("OK");
-            store = new ClassPathXmlApplicationContext("classpath:*applicationContext-jdbc-test.xml").getBean(FF4j.class)
-                    .getStore();
+            store = ff4j.getStore();
         }
         return store;
     }

--- a/ff4j-store-jdbc/src/test/resources/applicationContext-jdbc-test.xml
+++ b/ff4j-store-jdbc/src/test/resources/applicationContext-jdbc-test.xml
@@ -38,9 +38,9 @@
 	<bean id="dbStore" class="org.ff4j.store.FeatureStoreSpringJDBC" p:dataSource-ref="ff.jdbc.datasource" />
 	
 	<!-- enable the configuration of transactional behavior based on annotations -->
- 	<tx:annotation-driven transaction-manager="txManager"/>
+ 	<tx:annotation-driven transaction-manager="transactionManager"/>
   
-	<bean id="txManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
  	 	<property name="dataSource" ref="ff.jdbc.datasource"/>
 	</bean>
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
 		<version.slf4j>1.7.5</version.slf4j>
 		<version.logback>1.0.13</version.logback>
 		<version.junit>4.8.2</version.junit>
+        <version.cglib>3.1</version.cglib>
 		<version.hdldb>2.2.4</version.hdldb>
 		<version.spring>3.1.1.RELEASE</version.spring>
 		<version.spring.jmx>2.0.8</version.spring.jmx>
@@ -143,6 +144,11 @@
 				<artifactId>spring-tx</artifactId>
 				<version>${version.spring}</version>
 			</dependency>
+            <dependency>
+                <groupId>cglib</groupId>
+                <artifactId>cglib</artifactId>
+                <version>${version.cglib}</version>
+            </dependency>
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-web</artifactId>


### PR DESCRIPTION
Unit tests for Jdbc feature store are not written to be launch in a random order. Some of them check data source state (for example after initialization) and others modify it. In result if a test that modify data source state is run before the one checking it's well initialization, the build will fail. A solution is to add @Transactional on tests to be sure that a rollback is perform on the database after. 
In addition, unit tests for ehcache feature store were getting a cache from CacheManager holding a singleton. So caches were not delete. A solution is to add an @After method to remove all caches.
