### PR TITLE
Junit version change from 4.4 to 4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ mvn archetype:create -Dpackaging=jar -Dversion=1.0 -DartifactId=ff4j-simple -Dgr
 </features>
 ```
 
-* Write the following Junit test : (you may have to update junit version in your pom file with at least 4.4)
+* Write the following Junit test : (you may have to update junit version in your pom file with at least 4.5)
 
 ```java
 package org.ff4j.sample;


### PR DESCRIPTION
The JUnit test only works with 4.5 onwards, otherwise it will give a java.lang.NoClassDefFoundError: org/junit/runners/BlockJUnit4ClassRunner.
