### PR TITLE
ensure that initialization of FeatureCacheProviderEhCache is thread-safe 

### DIFF
--- a/ff4j-store-ehcache/src/main/java/org/ff4j/cache/FeatureCacheProviderEhCache.java
+++ b/ff4j-store-ehcache/src/main/java/org/ff4j/cache/FeatureCacheProviderEhCache.java
@@ -81,18 +81,14 @@ public class FeatureCacheProviderEhCache implements FF4JCacheManager {
     /**
      * Initialize cache
      */
-    private void initializeCache() {
-        if (null == getCacheConfiguration()) {
-            this.cacheManager = CacheManager.create();
-        } else {
-            this.cacheManager = CacheManager.create(getCacheConfiguration());  
+    private synchronized void initializeCache() {
+        if (cacheManager == null) {
+            cacheManager = cacheConfiguration == null
+                           ? CacheManager.create()
+                           : CacheManager.create(cacheConfiguration);
         }
-        if (!cacheManager.cacheExists(CACHENAME_FEATURES)) {
-            cacheManager.addCache(CACHENAME_FEATURES);
-        }
-        if (!cacheManager.cacheExists(CACHENAME_PROPERTIES)) {
-            cacheManager.addCache(CACHENAME_PROPERTIES);
-        }
+        cacheManager.addCacheIfAbsent(CACHENAME_FEATURES);
+        cacheManager.addCacheIfAbsent(CACHENAME_PROPERTIES);
         cacheFeatures   = cacheManager.getCache(CACHENAME_FEATURES);
         cacheProperties = cacheManager.getCache(CACHENAME_PROPERTIES);
         LOG.debug("CacheManager initialized as '{}'", cacheFeatures.getName());

--- a/ff4j-store-ehcache/src/main/java/org/ff4j/cache/FeatureCacheProviderEhCache.java
+++ b/ff4j-store-ehcache/src/main/java/org/ff4j/cache/FeatureCacheProviderEhCache.java
@@ -46,10 +46,10 @@ public class FeatureCacheProviderEhCache implements FF4JCacheManager {
     /** The cache manager. */
     private CacheManager cacheManager;
     
-    /** Eh Cache - cache-aside mode utlization. */
+    /** Eh Cache - cache-aside mode utilization. */
     private Cache cacheFeatures = null;
     
-    /** Eh Cache - cache-aside mode utlization. */
+    /** Eh Cache - cache-aside mode utilization. */
     private Cache cacheProperties = null;
 
     /**
@@ -79,7 +79,7 @@ public class FeatureCacheProviderEhCache implements FF4JCacheManager {
     }
 
     /**
-     * Ininitialize cache
+     * Initialize cache
      */
     private void initializeCache() {
         if (null == getCacheConfiguration()) {
@@ -108,7 +108,6 @@ public class FeatureCacheProviderEhCache implements FF4JCacheManager {
     @Override
     public void clearProperties() {
         getCacheProperties().flush();
-        
     }
 
     /** {@inheritDoc} */

--- a/ff4j-store-ehcache/src/main/java/org/ff4j/ehcache/FF4jEhCacheWrapper.java
+++ b/ff4j-store-ehcache/src/main/java/org/ff4j/ehcache/FF4jEhCacheWrapper.java
@@ -49,10 +49,10 @@ public final class FF4jEhCacheWrapper {
     /** Configuration file. */
     private InputStream cacheConfigurationFile;
    
-    /** Eh Cache - cache-aside mode utlization. */
+    /** Eh Cache - cache-aside mode utilization. */
     private Cache cacheFeatures = null;
     
-    /** Eh Cache - cache-aside mode utlization. */
+    /** Eh Cache - cache-aside mode utilization. */
     private Cache cacheProperties = null;
     
     /**


### PR DESCRIPTION
I've run into a concurrency issue with the Ehcache integration:
```
net.sf.ehcache.ObjectExistsException: Cache ff4jCacheFeatures already exists
        at net.sf.ehcache.CacheManager.addCache(CacheManager.java:1237) ~[ehcache-2.10.4.jar!/:2.10.4]
        at org.ff4j.cache.FeatureCacheProviderEhCache.initializeCache(FeatureCacheProviderEhCache.java:91) ~[ff4j-store-ehcache-1.7.1.jar!/:1.7.1]
        at org.ff4j.cache.FeatureCacheProviderEhCache.getCacheFeatures(FeatureCacheProviderEhCache.java:184) ~[ff4j-store-ehcache-1.7.1.jar!/:1.7.1]
        at org.ff4j.cache.FeatureCacheProviderEhCache.getFeature(FeatureCacheProviderEhCache.java:141) ~[ff4j-store-ehcache-1.7.1.jar!/:1.7.1]
        at org.ff4j.cache.FF4jCacheProxy.read(FF4jCacheProxy.java:134) ~[ff4j-core-1.7.1.jar!/:1.7.1]
        at org.ff4j.audit.proxy.FeatureStoreAuditProxy.read(FeatureStoreAuditProxy.java:213) ~[ff4j-core-1.7.1.jar!/:1.7.1]
        at org.ff4j.FF4j.getFeature(FF4j.java:427) ~[ff4j-core-1.7.1.jar!/:1.7.1]
        at org.ff4j.FF4j.check(FF4j.java:176) ~[ff4j-core-1.7.1.jar!/:1.7.1]
        at org.ff4j.FF4j.check(FF4j.java:163) ~[ff4j-core-1.7.1.jar!/:1.7.1]
        [...]
```

I think it's fair for a user to assume that ff4j.check(...) is thread-safe, but that's not the case when the Ehcache integration is used.  This PR helps with that.

I have used the following code to "verify" that the fix works:
```
package org.ff4j.cache;

import static org.junit.Assert.assertTrue;
import org.junit.Test;

import java.util.ArrayList;
import java.util.List;
import java.util.concurrent.Callable;
import java.util.concurrent.CountDownLatch;
import java.util.concurrent.ExecutorService;
import java.util.concurrent.Executors;

public class FeatureCacheProviderEhCacheConcurrencyTest {
    @Test
    public void test() throws InterruptedException {
        final int times = 1;
        final int threads = 10;
        final List<Throwable> exceptions = new ArrayList<Throwable>();
        for (int n = 0; n < times; n++) {
            final CountDownLatch latch = new CountDownLatch(1);
            final CountDownLatch globalLatch = new CountDownLatch(threads);
            final FeatureCacheProviderEhCache cut = new FeatureCacheProviderEhCache();
            final ExecutorService executor = Executors.newFixedThreadPool(threads);
            final Callable<?> c = new Callable<Void>() {
                @Override
                public Void call() {
                    try {
                        latch.await();
                        cut.getCacheFeatures();
                    } catch (Exception e) {
                        exceptions.add(e);
                        e.printStackTrace();
                    } finally {
                        globalLatch.countDown();
                    }
                    return null;
                }
            };
            for (int i = 0; i < threads; i++) {
                executor.submit(c);
            }
            latch.countDown();
            globalLatch.await();
            executor.shutdownNow();
        }
        assertTrue(exceptions.isEmpty());
    }
}
```