### PR TITLE
Display 'property' description in the edit dialog

### DIFF
--- a/ff4j-web/src/main/resources/static/js/ff4j.js
+++ b/ff4j-web/src/main/resources/static/js/ff4j.js
@@ -276,7 +276,7 @@ function ff4j_updateModalEditProperty(name) {
   $.get('api/properties/' + name, 
     function(myProperty) {
 	  modalEditProperty.find("#name").val(myProperty.name);
-	  modalEditProperty.find("#desc").val(myProperty.description);
+	  modalEditProperty.find("#pDesc").val(myProperty.description);
 	  modalEditProperty.find("#pType").val(myProperty.type);
 	  modalEditProperty.find("#pValue").val(myProperty.value);
       ff4j_drawFixedValues(myProperty.name);


### PR DESCRIPTION
The modal dialog on the admin interface doesn't display the description of the property, because the html has a different id, than the expected.