### PR TITLE
update cache manager reference on CacheProxy without clearning old ca…

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/cache/Store2CachePollingScheduler.java
+++ b/ff4j-core/src/main/java/org/ff4j/cache/Store2CachePollingScheduler.java
@@ -72,6 +72,23 @@ public class Store2CachePollingScheduler implements Serializable{
             }
         });
     }
+
+    /**
+     * Parameterized constructor.
+     * @param fcp
+     *      cache proxy
+     */
+    public Store2CachePollingScheduler(FF4jCacheProxy fcp) {
+        worker = new Store2CachePollingWorker(fcp);
+        executor = Executors.newScheduledThreadPool(1, new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread t = new Thread(r, "FF4j_Store2CachePollingWorker");
+                t.setDaemon(true);
+                return t;
+            }
+        });
+    }
     
     /**
      * Start polling with a polling

--- a/ff4j-core/src/test/java/org/ff4j/test/cache/CacheProxyWithPollingTest.java
+++ b/ff4j-core/src/test/java/org/ff4j/test/cache/CacheProxyWithPollingTest.java
@@ -76,7 +76,29 @@ public class CacheProxyWithPollingTest {
         FF4jCacheProxy proxy = new FF4jCacheProxy();
         proxy.stopPolling();
     }
-    
+
+
+    @Test
+    public void testCacheProxyManagerPropertyDuringRefresh() throws InterruptedException {
+        // When
+        FeatureStore  fs     = new InMemoryFeatureStore("ff4j.xml");
+        PropertyStore ps     = new InMemoryPropertyStore("ff4j.xml");
+        FF4JCacheManager cm  = new InMemoryCacheManager();
+        FF4jCacheProxy proxy = new FF4jCacheProxy(fs, ps, cm);
+
+        Store2CachePollingScheduler scheduler = proxy.getStore2CachePoller();
+        // Start polling on 10ms basis to refresh cache with properties and features
+        scheduler.setPollingDelay(10);
+        scheduler.start();
+
+        Thread.sleep(1000);
+
+        // Make a number of requests to get a property from the Cache Manager
+        // The property should never be null
+        for (int i=0; i<10000; i++) {
+            Assert.assertNotNull(proxy.getCacheManager().getProperty("a"));
+        }
+    }
     
     
 


### PR DESCRIPTION
Currently, the working thread polls and fetches data from store and copies to local cache by clearing the properties/features from the cache ( cacheManager.clearProperties() ) and thereafter, populating individual properties in a loop ( cacheManager.putProperty(p) ).

This PR is to make this refresh operation atomic by updating the underlying cache manager reference on the FF4jCacheProxy without clearing the old cache manager. This will avoid the possibility of Property<?> fp = getCacheManager().getProperty(name) returning null during the cache refresh, which otherwise makes a remote call for the property to the server.