### PR TITLE
Added horizontal scrollbar to table in case of overflow

### DIFF
--- a/ff4j-web/src/main/resources/static/css/style.css
+++ b/ff4j-web/src/main/resources/static/css/style.css
@@ -60,6 +60,11 @@ textarea {
   border-top: 1px solid #dddddd;
 }
 
+.table{
+	display:block;
+	overflow-x:auto;
+	overflow-y:hidden;
+}
 
 /*------------------------------------------------------------------
 [2. Navbar / .navbar]


### PR DESCRIPTION
For Features and Properties table, in case of an overflow, a horizontal scrollbar is added. This is with regard to issue #316 . 

Without scrollbar
![without_scrollbar](https://user-images.githubusercontent.com/5358197/44884096-cec1fd80-ac6e-11e8-8567-c7d293f45726.png)

With scrollbar
![with_scrollbar](https://user-images.githubusercontent.com/5358197/44884119-ed27f900-ac6e-11e8-98aa-49a6dca877a5.png)
