### PR TITLE
[Bugfix] Remove extra '/' character when using FF4J_PREFIXKEY

### DIFF
--- a/ff4j-store-consul/src/main/java/org/ff4j/consul/ConsulConnection.java
+++ b/ff4j-store-consul/src/main/java/org/ff4j/consul/ConsulConnection.java
@@ -259,7 +259,7 @@ public class ConsulConnection implements KeyValueDriver< String, String > {
     /** {@inheritDoc} */
     @Override
     public String getHitCountKey(Event e) {
-        return ConsulConstants.FF4J_PREFIXKEY_HITS + "/" + 
+        return ConsulConstants.FF4J_PREFIXKEY_HITS +
                     KDF.format(e.getTimestamp()) + "/"   +
                     e.getName() + "/" + e.getUuid();
     }
@@ -267,7 +267,7 @@ public class ConsulConnection implements KeyValueDriver< String, String > {
     /** {@inheritDoc} */
     @Override
     public String getMissKey(Event e) {
-        return ConsulConstants.FF4J_PREFIXKEY_MISS + "/" + 
+        return ConsulConstants.FF4J_PREFIXKEY_MISS +
                 KDF.format(e.getTimestamp()) + "/"   +
                 e.getName() + "/" + e.getUuid();
     }
@@ -275,7 +275,7 @@ public class ConsulConnection implements KeyValueDriver< String, String > {
     /** {@inheritDoc} */
     @Override
     public String getAuditTrailKey(Event e) {
-        return ConsulConstants.FF4J_PREFIXKEY_AUDIT + "/" + 
+        return ConsulConstants.FF4J_PREFIXKEY_AUDIT +
                 KDF.format(e.getTimestamp()) + "/"   +
                 e.getName() + "/" + e.getUuid();
     }


### PR DESCRIPTION
The constants in ConsulConstants.FF4J_PREFIXKEY already have a trailing slash.  When trying
to store audit logs in Consul, the current implementation tries to store with keys containing "//", which causes an error.