### PR TITLE
Add spring boot configuration processor dependency

### DIFF
--- a/ff4j-spring-boot-autoconfigure/pom.xml
+++ b/ff4j-spring-boot-autoconfigure/pom.xml
@@ -49,6 +49,12 @@
             <artifactId>ff4j-web</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
     <build>
         <finalName>ff4j-spring-boot-autoconfigure</finalName>


### PR DESCRIPTION
This dependency generate metadata needed to help Spring Boot with the
startup time.