### PR TITLE
feat: add a var attribute to the taglib API

### DIFF
--- a/ff4j-web/src/main/java/org/ff4j/web/taglib/FeatureTagDisable.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/taglib/FeatureTagDisable.java
@@ -29,6 +29,18 @@ import org.ff4j.core.FlippingExecutionContext;
 
 /**
  * Content of enclosing tag will be displayed if feature not enable.
+ *
+ * <p/>
+ *
+ * It is also possible to store the result of feature evaluation to be able to use it in a more complex
+ * condition:
+ *
+ * <pre><code>
+ *     &lt;ff4j:disable featureid="mercure-desc" var="mercureDescDisabled"&gt;
+ *     &lt;c:if test=${mercureDescDisabled && otherCondition}"&gt;
+ *       Your HTML code
+ *     &lt;/c:if"&gt;
+ * </code></pre>
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */

--- a/ff4j-web/src/main/java/org/ff4j/web/taglib/FeatureTagEnable.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/taglib/FeatureTagEnable.java
@@ -31,7 +31,19 @@ import org.ff4j.core.FlippingExecutionContext;
  * &lt;ff4j:enable featureid="mercure-desc"&gt;
  * here your html code
  *  &lt;/ff4j:enable@gt;
- * 
+ *
+ * <p/>
+ *
+ * It is also possible to store the result of feature evaluation to be able to use it in a more complex
+ * condition:
+ *
+ * <pre><code>
+ *     &lt;ff4j:disable featureid="mercure-desc" var="mercureDescEnabled"&gt;
+ *     &lt;c:if test=${mercureDescEnabled && otherCondition}"&gt;
+ *       Your HTML code
+ *     &lt;/c:if"&gt;
+ * </code></pre>
+
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
 public class FeatureTagEnable extends AbstractFeatureTag {

--- a/ff4j-web/src/main/resources/META-INF/tags/ff4j.tld
+++ b/ff4j-web/src/main/resources/META-INF/tags/ff4j.tld
@@ -29,6 +29,24 @@
    		<required>false</required>
    		<rtexprvalue>false</rtexprvalue>
   	 </attribute>
+		<attribute>
+			<description>
+				Name of the exported scoped variable for the
+				resulting value of the feature condition. The type
+				of the scoped variable is Boolean.
+			</description>
+			<name>var</name>
+			<required>false</required>
+			<rtexprvalue>false</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>
+				Scope for var.
+			</description>
+			<name>scope</name>
+			<required>false</required>
+			<rtexprvalue>false</rtexprvalue>
+		</attribute>
 	</tag>
 	
 	<!-- Check Feature status -->
@@ -49,6 +67,24 @@
    		<required>false</required>
    		<rtexprvalue>false</rtexprvalue>
   	 </attribute>
+		<attribute>
+			<description>
+				Name of the exported scoped variable for the
+				resulting value of the feature condition. The type
+				of the scoped variable is Boolean.
+			</description>
+			<name>var</name>
+			<required>false</required>
+			<rtexprvalue>false</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>
+				Scope for var.
+			</description>
+			<name>scope</name>
+			<required>false</required>
+			<rtexprvalue>false</rtexprvalue>
+		</attribute>
 	</tag>
 	
 


### PR DESCRIPTION
Hi,

This PR add an optional attribute to the taglib API to be able to store the feature condition into a variable (such as the `var` attribute of the `c:if` taglib).
It can be used like this:
```xml
<ff4j:enable featureid="my-awesome-feature" var="myAwesomeFeature"/>
<c:if test="${myAwesome && otherCondition}">
  YOUR HTML CODE
</c:if>
```

This can be useful in a lot of use case when you only need a variable in a more complex test or when you want to evaluate the feature condition once and re-user this variable multiple times.
