### PR TITLE
Fix NullPointerException in doPost

### DIFF
--- a/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleServlet.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleServlet.java
@@ -109,7 +109,9 @@ public class ConsoleServlet extends HttpServlet {
         LOGGER.info("|_| |_|    |_|_/ |");
         LOGGER.info("             |__/   Embedded Console - v" + getClass().getPackage().getImplementationVersion());
         LOGGER.info(" ");
-        
+
+        super.init(servletConfig);
+
         if (ff4j == null) {
             String className = servletConfig.getInitParameter(PROVIDER_PARAM_NAME);
             try {


### PR DESCRIPTION
Prior to this fix, the following line throws a NPE in doPost() due to the servlet config not being properly stored in the 'config' member variable of GenericServlet since ConsoleServlet does not call it's super.init(servletConfig) method: 
getServletContext().setAttribute(FF4J_SESSIONATTRIBUTE_NAME, ff4j);

Reproduction for the error is just the following:
1) Access the web console for FF4J
2) Click the New Property button
3) Fill out the form with the following:
Name: test
Description: test
Type: org.ff4j.property.PropertyInt
Value: 0
4) Click the Create button

For the time being I've worked around this problem by using reflection to forcefully set the property in a subclass of ConsoleServlet:
```
public class CustomConsoleServlet extends ConsoleServlet {
    @Override
    public void init(ServletConfig servletConfig) throws ServletException {
      super.init(servletConfig);
        try {
            Field f = GenericServlet.class.getDeclaredField("config");
            f.setAccessible(true);
            f.set(this, servletConfig);
            log.info("Forcefully set servlet config into CustomConsoleServlet");
        } catch (NoSuchFieldException e) {
            log.error("Field missing!", e);
        } catch (IllegalAccessException e) {
            log.error("Illegal Access!", e);
        }
    }
}

```