### PR TITLE
Using AnnotatedElementUtils instead of AnnotationUtils

### DIFF
--- a/ff4j-aop/src/main/java/org/ff4j/aop/FeatureAdvisor.java
+++ b/ff4j-aop/src/main/java/org/ff4j/aop/FeatureAdvisor.java
@@ -31,6 +31,7 @@ import org.springframework.aop.framework.AopProxyUtils;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
@@ -126,16 +127,16 @@ public class FeatureAdvisor implements MethodInterceptor {
      *      the associated annotation
      */
     protected Flip getFF4jAnnotation(MethodInvocation mi) {
-        if (mi.getMethod().isAnnotationPresent(Flip.class)) {
-            return mi.getMethod().getAnnotation(Flip.class);
+        if (AnnotatedElementUtils.hasAnnotation(mi.getMethod(), Flip.class)) {
+            return AnnotatedElementUtils.findMergedAnnotation(mi.getMethod(), Flip.class);
         }
-        Class <?> currentInterface = mi.getMethod().getDeclaringClass();
-        if (currentInterface.isAnnotationPresent(Flip.class)) {
-            return currentInterface.getAnnotation(Flip.class);
+        Class<?> currentInterface = mi.getMethod().getDeclaringClass();
+        if (AnnotatedElementUtils.hasAnnotation(currentInterface, Flip.class)) {
+            return AnnotatedElementUtils.findMergedAnnotation(currentInterface, Flip.class);
         }
-        Class <?> currentImplementation = getExecutedClass(mi);
-        if (currentImplementation.isAnnotationPresent(Flip.class)) {
-            return currentImplementation.getAnnotation(Flip.class);
+        Class<?> currentImplementation = getExecutedClass(mi);
+        if (AnnotatedElementUtils.hasAnnotation(currentImplementation, Flip.class)) {
+            return AnnotatedElementUtils.findMergedAnnotation(currentImplementation, Flip.class);
         }
         return null;
     }

--- a/ff4j-aop/src/main/java/org/ff4j/aop/FeatureAutoProxy.java
+++ b/ff4j-aop/src/main/java/org/ff4j/aop/FeatureAutoProxy.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.springframework.aop.TargetSource;
 import org.springframework.aop.framework.autoproxy.AbstractAutoProxyCreator;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ClassUtils;
 
@@ -108,20 +109,20 @@ public class FeatureAutoProxy extends AbstractAutoProxyCreator {
     }
     
     private Object[] scanInterfaceForAnnotation(Class<?> currentInterface, String currentInterfaceName) {
-        // Interface never scan 
-        if (currentInterface.isAnnotationPresent(Flip.class)) {
+        // Interface never scan
+        if (AnnotatedElementUtils.hasAnnotation(currentInterface, Flip.class)) {
             processedInterface.put(currentInterfaceName, true);
             return PROXY_WITHOUT_ADDITIONAL_INTERCEPTORS;
-            
-         } else {
-             // not found on bean, check methods
-             for (Method method : currentInterface.getDeclaredMethods()) {
-                 if (method.isAnnotationPresent(Flip.class)) {
-                     processedInterface.put(currentInterfaceName, true);
-                     return PROXY_WITHOUT_ADDITIONAL_INTERCEPTORS;
-                 }
-             }
-         }
+
+        } else {
+            // not found on bean, check methods
+            for (Method method : currentInterface.getDeclaredMethods()) {
+                if (AnnotatedElementUtils.hasAnnotation(method, Flip.class)) {
+                    processedInterface.put(currentInterfaceName, true);
+                    return PROXY_WITHOUT_ADDITIONAL_INTERCEPTORS;
+                }
+            }
+        }
         // annotation has not been found
         processedInterface.put(currentInterfaceName, false);
         return null;


### PR DESCRIPTION
Using AnnotatedElementUtils instead of AnnotationUtils to allow composed annotations with @Flip. See Spring documentation for Class AnnotationUtils "For fine-grained support for meta-annotations with attribute overrides in composed annotations, consider using AnnotatedElementUtils's more specific methods instead."