### PR TITLE
Deprecate fromJson method from Feature

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/core/Feature.java
+++ b/ff4j-core/src/main/java/org/ff4j/core/Feature.java
@@ -222,9 +222,17 @@ public class Feature implements Serializable {
         json.append("}");
         return json.toString();
     }
-    
+
+    /**
+     * Converts from JSON String to Feature.
+     * @param jsonString
+     *            the JSON String representation of the Feature.
+     * @return null
+     * @deprecated See FeatureJsonParser from the ff4j-utils-json package.
+     */
+    @Deprecated
     public static Feature fromJson(String jsonString) {
-        return null;
+      throw new UnsupportedOperationException();
     }
     
     /**


### PR DESCRIPTION
This PR deprecates the `fromJson` static method from `Feature` as it is currently not used and used to return null. I have added an `UnsupportedOperationException`. Let me know if this ok or if I should just leave it unchanged. 