### PR TITLE
Fix - Page cannot download resources on url without trainling slash.

### DIFF
--- a/ff4j-web/src/main/java/org/ff4j/web/FF4jDispatcherServlet.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/FF4jDispatcherServlet.java
@@ -46,6 +46,9 @@ public class FF4jDispatcherServlet extends FF4jServlet {
     /** {@inheritDoc} */
     public void doGet(HttpServletRequest req, HttpServletResponse res)
     throws ServletException, IOException {
+        // Issue #437 : resources cannot be obtained without trailing slash
+        if (redirectUrlWithoutSlash(req, res)) return;
+
         res.setCharacterEncoding(WebConstants.UTF8_ENCODING);
         
     	String targetView  = getTargetView(req);
@@ -64,6 +67,14 @@ public class FF4jDispatcherServlet extends FF4jServlet {
             res.setContentType("text/html");
         	mapOfControllers.get(targetView).get(req, res);
     	}
+    }
+
+    private boolean redirectUrlWithoutSlash(HttpServletRequest req, HttpServletResponse res) throws IOException {
+        if (req.getServletPath().equals(req.getRequestURI())) {
+            res.sendRedirect(req.getRequestURL() + "/");
+            return true;
+        }
+        return false;
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Issue: https://github.com/ff4j/ff4j/issues/437

For Get Request it will send redirect if there is missing trailing slash "<url>/ff-web/" is redirected to "<url>/ff-web/"

Key is this condition
"req.getServletPath().equals(req.getRequestURI())"

Can you see some issues? For me, it seems, that it should work well even for all projects, which already use it.