### PR TITLE
Fix issue with case insensitive databases

### DIFF
--- a/ff4j-store-mongodb-v3/src/main/java/org/ff4j/mongo/store/PropertyStoreMongo.java
+++ b/ff4j-store-mongodb-v3/src/main/java/org/ff4j/mongo/store/PropertyStoreMongo.java
@@ -228,7 +228,7 @@ public class PropertyStoreMongo extends AbstractPropertyStore {
                 .listCollectionNames()
                 .into(new HashSet<String>())
                 .contains(collectionName)) {
-            mongoClient.getDatabase(dbName).createCollection(collectionName);
+            mongoClient.getDatabase(dbName).getCollection(collectionName);
         }
         propertiesCollection = mongoClient.getDatabase(dbName).getCollection(collectionName);
     }

--- a/ff4j-store-mongodb-v3/src/test/java/org/ff4j/test/store/PropertyStoreMongoCollectionCore1Test.java
+++ b/ff4j-store-mongodb-v3/src/test/java/org/ff4j/test/store/PropertyStoreMongoCollectionCore1Test.java
@@ -47,8 +47,10 @@ public class PropertyStoreMongoCollectionCore1Test extends PropertyStoreTestSupp
 
      /** {@inheritDoc} */
     protected PropertyStore initPropertyStore() {
-        return new PropertyStoreMongo(
-                fongoRule.getDatabase().getCollection("ff4j"), "test-ff4j-features.xml");
+        PropertyStoreMongo propertyStoreMongo = new PropertyStoreMongo(fongoRule.getMongoClient());
+        propertyStoreMongo.importPropertiesFromXmlFile("test-ff4j-features.xml");
+
+        return propertyStoreMongo;
     }
     
     @Test
@@ -58,6 +60,6 @@ public class PropertyStoreMongoCollectionCore1Test extends PropertyStoreTestSupp
         Assert.assertNotNull(pod.getType("a"));
         Assert.assertNotNull(pod.getFixedValues("a"));
     }
-    
-    
+
+
 }

--- a/ff4j-store-springjdbc/pom.xml
+++ b/ff4j-store-springjdbc/pom.xml
@@ -22,6 +22,8 @@
 	<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 	<properties>
 		<license.licenseResolver>${project.baseUri}/../src/license</license.licenseResolver>
+		<testcontainers.version>1.14.3</testcontainers.version>
+		<postgresql.version>42.2.16</postgresql.version>
 	</properties>
 	
 	<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
@@ -78,6 +80,25 @@
 			<artifactId>spring-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		
+
+		<!-- Test against Docker Containers with Test Containers -->
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>test</scope>
+			<version>${testcontainers.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+			<scope>test</scope>
+			<version>${testcontainers.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>${postgresql.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/ff4j-store-springjdbc/src/main/java/org/ff4j/springjdbc/store/PropertyStoreSpringJdbc.java
+++ b/ff4j-store-springjdbc/src/main/java/org/ff4j/springjdbc/store/PropertyStoreSpringJdbc.java
@@ -213,23 +213,8 @@ public class PropertyStoreSpringJdbc extends AbstractPropertyStore {
     @Transactional
     public void createSchema() {
         JdbcQueryBuilder qb = getQueryBuilder();
-        if (!isTableExist(qb.getTableNameProperties())) {
+        if (!JdbcUtils.isTableExist(dataSource, qb.getTableNameProperties())) {
             getJdbcTemplate().update(qb.sqlCreateTableProperties());
         }
     }
-    
-    public boolean isTableExist(String tableName) {
-        ResultSet rs = null;
-        try {
-            DatabaseMetaData dbmd = 
-                    getJdbcTemplate().getDataSource().getConnection().getMetaData();
-            rs = dbmd.getTables(null, null, tableName, new String[] {"TABLE"});
-            return rs.next();
-        } catch (SQLException sqlEX) {
-            throw new FeatureAccessException("Cannot check table existence", sqlEX);
-        } finally {
-            JdbcUtils.closeResultSet(rs);
-        }
-    }
-
 }

--- a/ff4j-store-springjdbc/src/test/java/org/ff4j/test/store/docker/SpringJdbcPropertyStoreTestDocker.java
+++ b/ff4j-store-springjdbc/src/test/java/org/ff4j/test/store/docker/SpringJdbcPropertyStoreTestDocker.java
@@ -1,0 +1,89 @@
+package org.ff4j.test.store.docker;
+
+/*
+ * #%L
+ * ff4j-store-springjdbc
+ * %%
+ * Copyright (C) 2013 - 2016 FF4J
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+import javax.sql.DataSource;
+import org.ff4j.property.store.PropertyStore;
+import org.ff4j.springjdbc.store.PropertyStoreSpringJdbc;
+import org.ff4j.test.propertystore.PropertyStoreTestSupport;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * Check {@link PropertyStore} implementation through standard super class.
+ *
+ * @author Pedro Garcia Mota (@pedrompg)</a>
+ */
+public class SpringJdbcPropertyStoreTestDocker extends PropertyStoreTestSupport {
+
+    /**
+     * Constants.
+     **/
+    private static final String DOCKER_POSTGRES_IMAGE = "postgres:12-alpine";
+    /**
+     * Cassandra Containers.
+     **/
+    protected static PostgreSQLContainer<?> postgresContainer = null;
+    /**
+     * Datasource.
+     */
+    private DataSource dataSource;
+
+    @BeforeClass
+    public static void startDocker() {
+        postgresContainer = new PostgreSQLContainer<>(DOCKER_POSTGRES_IMAGE);
+        postgresContainer.start();
+    }
+
+    @AfterClass
+    public static void stopDocker() {
+        postgresContainer.stop();
+    }
+
+    public DataSource getDataSource() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.postgresql.Driver");
+        dataSource.setUrl(postgresContainer.getJdbcUrl());
+        dataSource.setUsername(postgresContainer.getUsername());
+        dataSource.setPassword(postgresContainer.getPassword());
+
+        return dataSource;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected PropertyStore initPropertyStore() {
+        if (dataSource == null) {
+            dataSource = getDataSource();
+        }
+        PropertyStoreSpringJdbc jdbcStore = new PropertyStoreSpringJdbc();
+        jdbcStore.setDataSource(dataSource);
+        jdbcStore.getJdbcTemplate();
+        jdbcStore.createSchema();
+        jdbcStore.importPropertiesFromXmlFile("test-ff4j-features.xml");
+        return jdbcStore;
+    }
+}

--- a/ff4j-test/src/main/java/org/ff4j/test/propertystore/PropertyStoreTestSupport.java
+++ b/ff4j-test/src/main/java/org/ff4j/test/propertystore/PropertyStoreTestSupport.java
@@ -79,6 +79,18 @@ public abstract class PropertyStoreTestSupport {
      */
     protected abstract PropertyStore initPropertyStore();
     
+    // --------------- schema creation -----------
+    @Test
+    public void multipleSchemaCreationOk() {
+        // Given
+        testedStore.createSchema();
+
+        // When
+        testedStore.createSchema();
+
+        // Then no exception
+    }
+
     // --------------- exist -----------
     
     /** TDD. */
@@ -106,7 +118,7 @@ public abstract class PropertyStoreTestSupport {
     }
     
     // --------------- create -----------    
-    
+
     /** TDD. */
     @Test
     public void addPropertyOKsimple() {
@@ -377,7 +389,4 @@ public abstract class PropertyStoreTestSupport {
             testedStore.createProperty(pName.getValue());
         }
     }
-    
-
-    
 }


### PR DESCRIPTION
When using PropertyStoreSpringJdbc together with DBs that
are case insensitive, like PostgreSQL, an exception was
being thrown when trying to create the schema, if it had
already been created before.

This commit leverages the existing JdbcUtils that
addresses properly the issue.

Also this commit updates PropertyStoreMongo to use
`getCollection` instead of `createCollection` when
creating schema because Fakemongo does not implement
a `createCollection` method, leads to exceptions.
`getCollection` will create a collection if didn't exist
 as per the documentation https://docs.mongodb.com/manual/reference/method/db.getCollection/#behavior

Closes https://github.com/ff4j/ff4j/issues/446