### PR TITLE
Edit PonderationStrategy java doc to reflect it's real purpose

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/strategy/PonderationStrategy.java
+++ b/ff4j-core/src/main/java/org/ff4j/strategy/PonderationStrategy.java
@@ -28,7 +28,7 @@ import org.ff4j.core.FeatureStore;
 import org.ff4j.core.FlippingExecutionContext;
 
 /**
- * This strategy will flip feature as soon as the release date is reached.
+ * This strategy will flip feature for a random % of calls.
  * 
  * @author Cedrick Lunven (@clunven)
  */


### PR DESCRIPTION
This strategy javadoc appears to have been copied from ReleaseDateFlipStrategy.
This aim to rewrite it to represent it's real purpose