### PR TITLE
issue 534 - Clear Cache Doesn't Clear Properties from Redis

### DIFF
--- a/ff4j-store-redis/pom.xml
+++ b/ff4j-store-redis/pom.xml
@@ -94,6 +94,7 @@
 			<groupId>org.testcontainers</groupId>
 			<artifactId>testcontainers</artifactId>
 			<version>${testcontainers.version}</version>
+			<scope>test</scope>
 		</dependency>
 		
 	</dependencies>

--- a/ff4j-store-redis/pom.xml
+++ b/ff4j-store-redis/pom.xml
@@ -25,7 +25,7 @@
 		<redis-forked>true</redis-forked>
 		<jedis.version>3.2.0</jedis.version>
 		<lettuce.version>5.3.1.RELEASE</lettuce.version>
-		<testcontainers.version>1.14.3</testcontainers.version>
+		<testcontainers.version>1.16.2</testcontainers.version>
 	</properties>
 
 	<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
@@ -89,6 +89,11 @@
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+			<version>${testcontainers.version}</version>
 		</dependency>
 		
 	</dependencies>

--- a/ff4j-store-redis/src/main/java/org/ff4j/cache/FF4jCacheManagerRedis.java
+++ b/ff4j-store-redis/src/main/java/org/ff4j/cache/FF4jCacheManagerRedis.java
@@ -136,16 +136,17 @@ public class FF4jCacheManagerRedis implements FF4JCacheManager {
     /** {@inheritDoc} */
     @Override
     public void clearProperties() {
-        Jedis jedis = null;
-        try {
-            jedis = getJedis();
-            jedis.del(keyBuilder.getKeyProperty("*"));
+        try ( Jedis jedis = getJedis() ) {
+            // --> This Pattern is not always supported
+            // jedis.del(KEY_PROPERTY + "*");
+            // <--
+            Set<String> matchingKeys = getKeys(jedis, keyBuilder.getKeyProperty("*"));
+
+            if (!matchingKeys.isEmpty()) {
+                jedis.del(matchingKeys.toArray(new String[matchingKeys.size()]));
+            }
         } catch(RuntimeException re) {
             onException(re);
-        } finally {
-            if (jedis != null) {
-                jedis.close();
-            }
         }
     }
 

--- a/ff4j-store-redis/src/test/java/org/ff4j/cache/it/PropertyStoreWithRedisCacheLettuceIT.java
+++ b/ff4j-store-redis/src/test/java/org/ff4j/cache/it/PropertyStoreWithRedisCacheLettuceIT.java
@@ -1,0 +1,44 @@
+package org.ff4j.cache.it;
+
+/*
+ * #%L
+ * ff4j-store-redis
+ * %%
+ * Copyright (C) 2021 FF4J
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import io.lettuce.core.RedisClient;
+import org.ff4j.cache.FF4JCacheManager;
+import org.ff4j.cache.FF4jCacheManagerRedisLettuce;
+import org.junit.Ignore;
+
+/**
+ * Test FF4jCacheManagerRedisLettuce caching of properties.
+ *
+ * @author <a href="https://github.com/mrgrew">Greg Wiley</a>
+ *
+ * Ignore because Docker may not be available in all cases.
+ */
+@Ignore
+public class PropertyStoreWithRedisCacheLettuceIT extends RedisTestSupport {
+
+    @Override
+    protected FF4JCacheManager makeCache() {
+        String redisUri = String.format("redis://%s:%d", redis.getHost(), redis.getFirstMappedPort());
+        return new FF4jCacheManagerRedisLettuce( RedisClient.create(redisUri) );
+    }
+
+}

--- a/ff4j-store-redis/src/test/java/org/ff4j/cache/it/PropertyStoreWithRedisCacheTestIT.java
+++ b/ff4j-store-redis/src/test/java/org/ff4j/cache/it/PropertyStoreWithRedisCacheTestIT.java
@@ -1,0 +1,40 @@
+package org.ff4j.cache.it;
+
+import io.lettuce.core.RedisClient;
+import org.ff4j.cache.FF4JCacheManager;
+import org.ff4j.cache.FF4jCacheManagerRedis;
+import org.ff4j.cache.FF4jCacheManagerRedisLettuce;
+import org.ff4j.cache.FF4jCacheProxy;
+import org.ff4j.core.Feature;
+import org.ff4j.core.FeatureStore;
+import org.ff4j.exception.FeatureAlreadyExistException;
+import org.ff4j.property.store.InMemoryPropertyStore;
+import org.ff4j.property.store.PropertyStore;
+import org.ff4j.redis.RedisConnection;
+import org.ff4j.test.store.FeatureStoreTestSupport;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.ff4j.test.TestsFf4jConstants.*;
+
+
+/**
+ * Test FF4jCacheManagerRedis caching of properties.
+ *
+ * @author <a href="https://github.com/mrgrew">Greg Wiley</a>
+ *
+ * Ignore because Docker may not be available in all cases.
+ */
+@Ignore
+public class PropertyStoreWithRedisCacheTestIT extends RedisTestSupport {
+
+    @Override
+    protected FF4JCacheManager makeCache() {
+        return new FF4jCacheManagerRedis(new RedisConnection(redis.getHost(), redis.getFirstMappedPort()));
+    }
+
+}

--- a/ff4j-store-redis/src/test/java/org/ff4j/cache/it/RedisTestSupport.java
+++ b/ff4j-store-redis/src/test/java/org/ff4j/cache/it/RedisTestSupport.java
@@ -1,0 +1,116 @@
+package org.ff4j.cache.it;
+
+/*
+ * #%L
+ * ff4j-store-redis
+ * %%
+ * Copyright (C) 2021 FF4J
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.ff4j.FF4j;
+import org.ff4j.cache.FF4JCacheManager;
+import org.ff4j.conf.XmlParser;
+import org.ff4j.property.store.PropertyStore;
+import org.ff4j.test.AssertFf4j;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.GenericContainer;
+
+import static org.ff4j.test.TestsFf4jConstants.TEST_FEATURES_FILE;
+
+/**
+ * Provide support to run Redis in a testcontainer
+ *
+ * @author <a href="https://github.com/mrgrew">Greg Wiley</a>
+ */
+public abstract class RedisTestSupport {
+
+    /** Initial sizes */
+    public static final int INITIAL_FEATURES_SIZE = 5;
+    public static final int INITIAL_PROPERTIES_SIZE = 12;
+
+    @Rule
+    public GenericContainer<?> redis = new GenericContainer<>("redis").withExposedPorts(6379);
+
+    protected abstract FF4JCacheManager makeCache();
+
+    /** Test Values */
+    protected AssertFf4j assertFf4j;
+
+    /** Initialize */
+    protected FF4j ff4j;
+
+    /** Cache Manager. */
+    protected FF4JCacheManager cache;
+
+    /** {@inheritDoc} */
+    @Before
+    public void setUp() throws Exception {
+        cache = makeCache();
+        ff4j = new FF4j(new XmlParser(), TEST_FEATURES_FILE);
+        ff4j.cache(cache);
+        assertFf4j = new AssertFf4j(ff4j);
+    }
+
+    @Test
+    public void testStoresAndCacheHaveBeenInitialized() {
+        assertFf4j.assertThatStoreHasSize(INITIAL_FEATURES_SIZE);
+        assertFf4j.assertThatPropertyStoreHasSize(INITIAL_PROPERTIES_SIZE);
+        Assert.assertTrue(cache.listCachedPropertyNames().isEmpty());
+    }
+
+    @Test
+    public void testOnePropertyIsCachedThenCleared() {
+        // Given
+        Assert.assertTrue(cache.listCachedPropertyNames().isEmpty());
+        // When
+        ff4j.getProperty("a");
+        // Then
+        Assert.assertEquals(1, cache.listCachedPropertyNames().size());
+        // When
+        cache.clearProperties();
+        // Then
+        Assert.assertTrue(cache.listCachedPropertyNames().isEmpty());
+    }
+
+    @Test
+    public void testAllPropertiesAreCachedThenCleared() {
+        // Given
+        Assert.assertTrue(cache.listCachedPropertyNames().isEmpty());
+        // When
+        PropertyStore propertyStore = ff4j.getPropertiesStore();
+        propertyStore.listPropertyNames().forEach(propertyStore::readProperty);
+        // Then
+        Assert.assertEquals(propertyStore.readAllProperties().size(), cache.listCachedPropertyNames().size());
+        // When
+        cache.clearProperties();
+        // Then
+        Assert.assertTrue(cache.listCachedPropertyNames().isEmpty());
+    }
+
+    @Test
+    public void testOneProperty() {
+        // Given
+        Assert.assertTrue(cache.listCachedPropertyNames().isEmpty());
+        // When
+        ff4j.getProperty("a");
+        // Then
+        Assert.assertEquals(1, cache.listCachedPropertyNames().size());
+    }
+
+}


### PR DESCRIPTION
When using the "ClearCache" feature of ff4j-web-console with a Redis cache, the FF4J properties are not cleared.

There are two issues:
1. The clearProperties() implementation in FF4jCacheManagerRedis and FF4jCacheManagerRedisLettuce attempt to delete the keys by wildcard instead of scanning for matching keys
2. The FF4jCacheManagerRedisLettuce getKeys() implementation only scans the first result instead of scanning until finished.

This pull request makes the changes above, and uses testcontainers to provide tests for those changes.

Resolves #534 