### PR TITLE
Remove unnecessary DB calls on readProperty and readGroup for Jdbc stores

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
@@ -156,13 +156,12 @@ public class JdbcPropertyStore extends AbstractPropertyStore {
         ResultSet         rs = null;
         try {
             sqlConn = getDataSource().getConnection();
-            if (!existProperty(name)) {
-                throw new PropertyNotFoundException(name);
-            }
-            // Returns features
+            // Returns property
             ps = buildStatement(sqlConn, getQueryBuilder().getProperty(), name);
             rs = ps.executeQuery();
-            rs.next();
+            if (!rs.next()) {
+                throw new PropertyNotFoundException(name);
+            }
             return JDBC_MAPPER.map(rs);
         } catch (SQLException sqlEX) {
             throw new PropertyAccessException("Cannot check property existence, error related to database", sqlEX);

--- a/ff4j-store-springjdbc/src/main/java/org/ff4j/springjdbc/store/FeatureStoreSpringJdbc.java
+++ b/ff4j-store-springjdbc/src/main/java/org/ff4j/springjdbc/store/FeatureStoreSpringJdbc.java
@@ -316,11 +316,11 @@ public class FeatureStoreSpringJdbc extends AbstractFeatureStore {
         if (groupName == null || groupName.isEmpty()) {
             throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
-        if (!existGroup(groupName)) {
+        List<Feature> lFp = getJdbcTemplate().query(getQueryBuilder().getFeatureOfGroup(), FMAPPER, groupName);
+        if (lFp.isEmpty()) {
             throw new GroupNotFoundException(groupName);
         }
         LinkedHashMap<String, Feature> mapFP = new LinkedHashMap<String, Feature>();
-        List<Feature> lFp = getJdbcTemplate().query(getQueryBuilder().getFeatureOfGroup(), FMAPPER, groupName);
         for (Feature flipPoint : lFp) {
             mapFP.put(flipPoint.getUid(), flipPoint);
         }

--- a/ff4j-store-springjdbc/src/main/java/org/ff4j/springjdbc/store/PropertyStoreSpringJdbc.java
+++ b/ff4j-store-springjdbc/src/main/java/org/ff4j/springjdbc/store/PropertyStoreSpringJdbc.java
@@ -1,9 +1,5 @@
 package org.ff4j.springjdbc.store;
 
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-
 /*
  * #%L
  * ff4j-store-springjdbc
@@ -24,7 +20,9 @@ import java.util.List;
  * #L%
  */
 
-
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -40,6 +38,7 @@ import org.ff4j.store.JdbcQueryBuilder;
 import org.ff4j.utils.JdbcUtils;
 import org.ff4j.utils.Util;
 import org.springframework.beans.factory.annotation.Required;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.SingleColumnRowMapper;
 import org.springframework.stereotype.Repository;
@@ -105,11 +104,13 @@ public class PropertyStoreSpringJdbc extends AbstractPropertyStore {
     /** {@inheritDoc} */
     public Property<?> readProperty(String name) {
         Util.assertNotNull(name);
-        if (!existProperty(name)) {
+        Util.assertHasLength(name);
+        try {
+            return getJdbcTemplate().
+                    queryForObject(getQueryBuilder().getProperty(), PMAPPER, name);
+        } catch (EmptyResultDataAccessException ex) {
             throw new PropertyNotFoundException(name);
         }
-        return getJdbcTemplate().
-        		queryForObject(getQueryBuilder().getProperty(), PMAPPER, name);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Resolves issue #558 

The call to exists methods inside readGroup and readProperty costs one extra unnecessary DB call.
It was possible to make the method behave the same way while reducing this call.