### PR TITLE
Add NPE prevention on null authentication

### DIFF
--- a/ff4j-security-spring/src/main/java/org/ff4j/security/SpringSecurityAuthorisationManager.java
+++ b/ff4j-security-spring/src/main/java/org/ff4j/security/SpringSecurityAuthorisationManager.java
@@ -48,10 +48,10 @@ public class SpringSecurityAuthorisationManager extends AbstractAuthorizationMan
     /** {@inheritDoc} */
     public String getCurrentUserName() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (!(auth instanceof AnonymousAuthenticationToken)) {
-            return auth.getName();
+        if (null == auth || auth instanceof AnonymousAuthenticationToken) {
+            return "anonymous";
         }
-        return "anonymous";
+        return auth.getName();
     }   
 
 }


### PR DESCRIPTION
When a spring boot project starts up it doesn't provide an `Authentication` object until it started up. 
If we had [such code](https://github.com/cbot59/spring-boot-ff4j-demo/commit/e6758ef5998c16ee28cb8163963a5ce54db370a0#diff-a64c1dc651d28eb9d18a38cac4248a09bd2ab32fc8debce9e44b2990be496529R16) it leads to spring boot project being failed to start up. 

Edit:
Just found out, the issue is coming caused by my [FF4JConfig](https://github.com/cbot59/spring-boot-ff4j-demo/commit/e6758ef5998c16ee28cb8163963a5ce54db370a0#diff-b44d89b238c5674011be19eb00bd32f19ef8c4b7ba405764655e7f4bd116cfa1R15) initialized audit as `true` leads to any feature created programmatically requires `Authentication` as a part of sending event for auditing purposes.