### PR TITLE
Fix Thymeleaf deprecation warnings #701

### DIFF
--- a/ff4j-web/src/main/resources/views/view-404.html
+++ b/ff4j-web/src/main/resources/views/view-404.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:include="header :: head"></head>
+<head th:insert="~{header :: head}"></head>
 <body>
-  
-<div class="navbar navbar-fixed-top" th:include="navbar :: navbar"></div>
+
+<div class="navbar navbar-fixed-top" th:insert="~{navbar :: navbar}"></div>
 
 <div id="wrapper" class="container" >
  <div class="row">
-  <div class="span9"> 
+  <div class="span9">
    <div id="content" class="clearfix" >
     <div class="main-inner" >
      <div class="container">
@@ -19,22 +19,22 @@
 				<div class="error-details">
 					<span th:text="#{404.subtitle}">title</span>
 				</div> <!-- /error-details -->
-				
+
 				<div class="error-actions">
 					<a href="index.html" th:href="@{home}" class="btn btn-large btn-green">
 						<i class="icon-chevron-left"></i>
 						&nbsp;
-						<span th:text="#{404.back}">title</span>						
+						<span th:text="#{404.back}">title</span>
 					</a>
-					
-					
-					
+
+
+
 				</div> <!-- /error-actions -->
-							
-			</div> <!-- /error-container -->			
-			
+
+			</div> <!-- /error-container -->
+
 		</div> <!-- /span12 -->
-		
+
 	</div> <!-- /row -->
 
 
@@ -44,6 +44,6 @@
   </div>
  </div>
 </div>
-   
+
 </body>
 </html>

--- a/ff4j-web/src/main/resources/views/view-audit.html
+++ b/ff4j-web/src/main/resources/views/view-audit.html
@@ -1,42 +1,42 @@
 <!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
 
-<head th:include="header :: head"></head>
+<head th:insert="~{header :: head}"></head>
 <script type="text/javascript" src="" th:src="@{static/js/jquery/jquery-3.5.1.min.js}"></script>
 <script type="text/javascript" src="" th:src="@{static/js/bootstrap-datetimepicker.min.js}"></script>
 <link rel="stylesheet" type="text/css" media="all" href="" th:href="@{static/css/bootstrap-datetimepicker.min.css}" />
 
 <script type="text/javascript" src="" th:src="@{static/js/jquery.dataTables.min.js}"></script>
 <link rel="stylesheet" type="text/css" media="all" href="" th:href="@{static/css/jquery.dataTables.min.css}" />
- 
-<body>
-  
-<div class="navbar navbar-fixed-top" th:include="navbar :: navbar"></div>
 
-<div class="subnavbar" th:include="navbar :: subnavbaraudit"></div>
+<body>
+
+<div class="navbar navbar-fixed-top" th:insert="~{navbar :: navbar}"></div>
+
+<div class="subnavbar" th:insert="~{navbar :: subnavbaraudit}"></div>
 
 <div id="wrapper" class="container" >
 
- <div th:include="messages :: messagebar" style="margin-top:60px"></div>
- 
+ <div th:insert="~{messages :: messagebar}" style="margin-top:60px"></div>
+
  <div class="row">
-  <div class="span9"> 
+  <div class="span9">
    <div id="content" class="clearfix" >
     <div class="main-inner" >
      <div class="container">
- 
+
       <div class="row">
-       <div class="span12">     
+       <div class="span12">
         <div class="widget">
-       
+
         <div class="widget-header">
          <i class="icon-bar-chart"></i>
          <h3 th:text="#{audit.title}">Audit</h3>
         </div>
-       
-        <div class="widget-content" style="text-align:center"> 
 
-  
+        <div class="widget-content" style="text-align:center">
+
+
   <form class="form-horizontal" action="" th:action="@{audit}" method="POST">
   <h4 style="color:#00AB8B">
       <div id="datetimepickerFrom1" class="input-append date">
@@ -59,22 +59,22 @@
 	  </button>
    </h4>
  </form>
- 
+
  <script type="text/javascript">
   $(function() {
     $('#datetimepickerFrom1').datetimepicker({});
     $('#datetimepickerTo1').datetimepicker({});
   });
 </script>
-     
+
  <script type="text/javascript">
  $(document).ready(function(){
 	    $('#auditTable').DataTable();
 	});
  </script>
-                    
-    <table id="auditTable" name="auditTable" 
-           class="table table-striped table-bordered" 
+
+    <table id="auditTable" name="auditTable"
+           class="table table-striped table-bordered"
            style="margin-top:10px;">
      <thead>
       <tr>
@@ -90,14 +90,14 @@
             <td>
                 <span th:text="${#dates.format(event.date,'MM/dd/yyyy HH:mm:ss')}">---</span>
             </td>
-            
+
             <td>
                 <span style="color:#008bab" th:text="${event.action}">---</span>
                 <span th:text="${event.type}">---</span>
                 <b><span th:text="${event.name}">---</span></b>
              </td>
              <td><span th:text="${event.user}">---</span></td>
-             
+
              <td>
                 <li><span th:text="#{audit.table.hostname}"></span> : <span th:text="${event.hostName}">---</span></li>
                 <li><span th:text="#{audit.table.source}"></span> :  <span th:text="${event.source}">---</span></li></td>
@@ -112,7 +112,7 @@
             </tbody>
         <!-- FeatureName -->
        </table>
-                             
+
                             </div>
                             <!-- /widget-content -->
                         </div>
@@ -127,6 +127,6 @@
     </div>
   </div>
 </div>
-   
+
 </body>
 </html>

--- a/ff4j-web/src/main/resources/views/view-featureUsage.html
+++ b/ff4j-web/src/main/resources/views/view-featureUsage.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:include="header :: head"></head>
+<head th:insert="~{header :: head}"></head>
 
 <link rel="stylesheet" type="text/css" media="all" href="" th:href="@{static/js/jqplot/jquery.jqplot.min.css}" />
 
@@ -19,29 +19,29 @@
 <link rel="stylesheet" type="text/css" media="all" href="" th:href="@{static/css/bootstrap-datetimepicker.min.css}" />
 
 <body>
-  
-<div class="navbar navbar-fixed-top" th:include="navbar :: navbar"></div>
 
-<div class="subnavbar" th:include="navbar :: subnavbarsupervision"></div>
+<div class="navbar navbar-fixed-top" th:insert="~{navbar :: navbar}"></div>
+
+<div class="subnavbar" th:insert="~{navbar :: subnavbarsupervision}"></div>
 
 <div id="wrapper" class="container" >
  <div class="row">
-  <div class="span9"> 
+  <div class="span9">
    <div id="content" class="clearfix" >
     <div class="main-inner" style="margin-top:60px">
      <div class="container">
 
         <div class="row">
-       <div class="span12">     
+       <div class="span12">
         <div class="widget">
-       
+
         <div class="widget-header">
          <i class="icon-bar-chart"></i>
          <h3 th:text="#{audit.title}">Audit</h3>
         </div>
-       
+
         <div class="widget-content" style="text-align:center">
-        
+
          <form class="form-horizontal" action="" th:action="@{featureUsage}" method="POST">
     <h4 style="color:#00AB8B">
       <div id="datetimepickerFrom1" class="input-append date">
@@ -64,15 +64,15 @@
       </button>
    </h4>
  </form>
- 
-        
+
+
      </div>
      </div>
      </div>
      </div>
-     
+
         <div class="row">
-        
+
          <div class="span4">
 
  <div class="widget widget-nopad">
@@ -85,13 +85,13 @@
     <script th:inline="javascript">
         var startTime = /*[[${fromJS}]]*/ null;
         var endTime   = /*[[${toJS}]]*/ null;
-        $(document).ready(ff4j_renderPie('pie', 
+        $(document).ready(ff4j_renderPie('pie',
         		ff4j_computePieHitRatio('api/featureUsage/pieHitRatio', startTime, endTime)));
-    </script>  
+    </script>
    </div>
 </div>
 </div>
-                        
+
  <div class="span8">
   <div class="widget widget-nopad">
    <div class="widget-header">
@@ -101,17 +101,17 @@
    <div class="widget-content" style="padding:15x;">
    <div id="featureUsageBar" style="margin:20px"></div>
    <script>
-   
+
    $(document).ready(function() {
      var barChart = ff4j_getBarHitRatio(startTime, endTime);
-	 
+
      $('#featureUsageBar').jqplot([barChart.data], {
 	   title: barChart.title,
 	   seriesColors: barChart.color,
 	   seriesDefaults:{
 	      renderer:        $.jqplot.BarRenderer,
 	      pointLabels:     { show: true },
-	      rendererOptions: { 
+	      rendererOptions: {
 	    	  varyBarColor: true,
 	    	  barWidth: 25,
               barPadding: -25,
@@ -137,14 +137,14 @@
 	 });
    });
    </script>
-   
+
    </div>
   </div>
  </div>
 
 </div>
 <div class="row">
-                    
+
 <div class="span4">
  <div class="widget widget-nopad">
   <div class="widget-header">
@@ -154,9 +154,9 @@
   <div class="widget-content">
    <div id="pie-user" class="divpie"></div>
     <script  type="text/javascript">
-        $(document).ready(ff4j_renderPie('pie-user',  
+        $(document).ready(ff4j_renderPie('pie-user',
                 ff4j_computePieHitRatio('api/featureUsage/pieUserRatio', startTime, endTime)));
-    </script> 
+    </script>
   </div>
  </div>
 </div>
@@ -170,9 +170,9 @@
   <div class="widget-content">
    <div id="pie-host" class="divpie"></div>
      <script  type="text/javascript">
-        $(document).ready(ff4j_renderPie('pie-host',  
+        $(document).ready(ff4j_renderPie('pie-host',
                 ff4j_computePieHitRatio('api/featureUsage/pieHostRatio', startTime, endTime)));
-    </script>  
+    </script>
   </div>
  </div>
 </div>
@@ -186,9 +186,9 @@
   <div class="widget-content">
     <div id="pie-source" class="divpie"></div>
    <script  type="text/javascript">
-        $(document).ready(ff4j_renderPie('pie-source',  
+        $(document).ready(ff4j_renderPie('pie-source',
                 ff4j_computePieHitRatio('api/featureUsage/pieSourceRatio', startTime, endTime)));
-    </script> 
+    </script>
   </div>
  </div>
 </div>
@@ -208,6 +208,6 @@
     $('#datetimepickerTo1').datetimepicker({});
   });
 </script>
-   
+
 </body>
 </html>

--- a/ff4j-web/src/main/resources/views/view-features.html
+++ b/ff4j-web/src/main/resources/views/view-features.html
@@ -1,26 +1,26 @@
 <!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:include="header :: head">
+<head th:insert="~{header :: head}">
 </head>
 <!-- DataTables -->
 <script type="text/javascript" src="" th:src="@{static/js/jquery.dataTables.min.js}"></script>
 <link rel="stylesheet" type="text/css" media="all" href="" th:href="@{static/css/jquery.dataTables.min.css}" />
 
 <body>
-  
-<div class="navbar navbar-fixed-top" th:include="navbar :: navbar"></div>
 
-<div class="subnavbar" th:include="navbar :: subnavbarfeatures"></div>
+<div class="navbar navbar-fixed-top" th:insert="~{navbar :: navbar}"></div>
+
+<div class="subnavbar" th:insert="~{navbar :: subnavbarfeatures}"></div>
 
 <div id="wrapper" class="container" >
  <div class="row">
-  <div class="span9"> 
+  <div class="span9">
    <div id="content" class="clearfix" >
     <div class="main-inner" style="margin-top:60px;margin-left:-30px">
      <div class="container">
-     
-  <div th:include="messages :: messagebar"></div>
-    
+
+  <div th:insert="~{messages :: messagebar}"></div>
+
   <div class="span12">
    <div class="widget widget-nopad">
     <div class="widget-header">
@@ -28,14 +28,14 @@
 	 <h3><span th:text="#{feature.title}" >Features</span></h3>
     </div>
     <div class="widget-content" style="padding:10px;">
-   
+
    <script type="text/javascript">
     $(document).ready(function(){
         $('#featureTable').DataTable();
     });
  </script>
- 
-	<table id="featureTable" name="featureTable" 
+
+	<table id="featureTable" name="featureTable"
 	       class="table table-striped table-bordered" style="margin-top:10px">
      <thead>
       <tr>
@@ -62,15 +62,15 @@
 	  <td>
 	    <!-- Permissions -->
 	    <div th:if="${not #sets.isEmpty(feat.permissions)}" >
-	      <span style="float:left;" 
+	      <span style="float:left;"
             th:text="${#sets.size(feat.permissions)} + ' items'">x</span>
            <a th:id="'linkPerm-' + ${indexFeat.count}"
-             style="color:#00ab8b;float:left;" 
+             style="color:#00ab8b;float:left;"
              th:href="'javascript:showFeaturePermissions(' + ${indexFeat.count} + ')'">
              &nbsp;(<i class="icon-eye-open"></i>)
          </a>
          <a th:id="'linkhidePerm-' + ${indexFeat.count}"
-             style="float:left;" 
+             style="float:left;"
              th:href="'javascript:hideFeaturePermissions(' + ${indexFeat.count} + ')'"
              class="hide">
              &nbsp;(<i class="icon-eye-close"></i>)</a>
@@ -97,15 +97,15 @@
 	 <td>
 	  <!-- CustomProperties -->
 	  <div th:if="${not #maps.isEmpty(feat.customProperties)}" >
-         <span style="float:left;" 
+         <span style="float:left;"
          th:text="${#maps.size(feat.customProperties)} + ' items '">x</span>
          <a th:id="'linkCustomP-' + ${indexFeat.count}"
-             style="color:#00ab8b;float:left;" 
+             style="color:#00ab8b;float:left;"
              th:href="'javascript:showCustomProperties(' + ${indexFeat.count} + ')'">
              (<i class="icon-eye-open"></i>)
          </a>
          <a th:id="'linkhideCustomP-' + ${indexFeat.count}"
-             style="color:#00ab8b;float:left;" 
+             style="color:#00ab8b;float:left;"
              th:href="'javascript:hideCustomProperties(' + ${indexFeat.count} + ')'"
              class="hide">
              (<i class="icon-eye-close"></i>)</a>
@@ -124,7 +124,7 @@
      <!-- Toggle -->
 	 <td style="width:8%;text-align:center">
 	  <label class="switch switch-green" th:disabled="${!enableEdit}">
-	   <input th:attr="id=${feat.uid}" id="x" 
+	   <input th:attr="id=${feat.uid}" id="x"
 	   		  type="checkbox" class="switch-input" th:onclick="${enableEdit}? 'javascript:toggle(this)'"
               th:checked="${feat.enable}" th:disabled="${!enableEdit}"/>
 		<span class="switch-label" data-on="On" data-off="Off"></span>
@@ -133,7 +133,7 @@
 	 </td>
      <!-- Edit -->
 	 <td style="width:5%;text-align:center" th:if="${enableEdit}">
-	  <a data-toggle="modal" href="#modalEdit" 
+	  <a data-toggle="modal" href="#modalEdit"
 	     th:attr="data-id=${feat.uid}"
 		 style="width:6px;margin-left:-3px;color:white;background-color:#008bab"
 		 class="open-EditFlipDialog btn">
@@ -142,7 +142,7 @@
 	 </td>
      <!-- Delete -->
 	 <td style="width:5%;text-align:center" th:if="${enableEdit}">
-	   <a data-toggle="modal" href="#modalDeleteFeature" 
+	   <a data-toggle="modal" href="#modalDeleteFeature"
          th:attr="data-id=${feat.uid}"
          style="width:6px;margin-left:-3px;color:white;background-color:#ab0000"
          class="open-DeleteFlipDialog btn">
@@ -155,29 +155,29 @@
     </div>
    </div>
   </div>
-     
+
 	 </div>
 	</div>
    </div>
   </div>
  </div>
 </div>
-   
-<div th:include="modal-features :: modal-deleteFeature"></div>
 
-<div th:include="modal-features :: modal-toggle"></div>
+<div th:insert="~{modal-features :: modal-deleteFeature}"></div>
 
-<div th:include="modal-features :: modal-edit"></div>
+<div th:insert="~{modal-features :: modal-toggle}"></div>
 
-<div th:include="modal-features :: modal-create"></div>
+<div th:insert="~{modal-features :: modal-edit}"></div>
 
-<div th:include="modal-features :: modal-rename"></div>
+<div th:insert="~{modal-features :: modal-create}"></div>
 
-<div th:include="modal-features :: modal-copy"></div>
+<div th:insert="~{modal-features :: modal-rename}"></div>
 
-<div th:include="modal-properties :: modal-createProperty"></div>
+<div th:insert="~{modal-features :: modal-copy}"></div>
 
-<div th:include="modal-properties :: modal-updateProperty"></div>
+<div th:insert="~{modal-properties :: modal-createProperty}"></div>
+
+<div th:insert="~{modal-properties :: modal-updateProperty}"></div>
 
 </body>
 </html>

--- a/ff4j-web/src/main/resources/views/view-header.html
+++ b/ff4j-web/src/main/resources/views/view-header.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
- 
- <head th:fragment="head">
-   
+
+ <head th:fragment="head" th:remove="tag">
+
    <meta http-equiv="Cache-Control"          content="no-store" />
    <meta http-equiv="Pragma"                 content="no-cache" />
    <meta http-equiv="Content-Type"           content="text/html;charset=utf-8" />
@@ -23,17 +23,17 @@
     <link rel="stylesheet" type="text/css" media="all" href="" th:href="@{static/css/font-awesome-3.2.1.css}" />
     <link rel="stylesheet" type="text/css" media="all" href="" th:href="@{static/css/style.css}" />
     <link rel="stylesheet" type="text/css" media="all" href="" th:href="@{static/css/dashboard.css}" />
- 
+
     <!-- JS -->
     <script type="text/javascript" src="" th:src="@{static/js/jquery/jquery-3.5.1.min.js}"></script>
     <script type="text/javascript" src="" th:src="@{static/js/bootstrap.js}"></script>
     <script type="text/javascript" src="" th:src="@{static/js/base.js}"></script>
     <script type="text/javascript" src="" th:src="@{static/js/ff4j.js}"></script>
-    
+
     <title th:text="'FF4J - ' + ${TITLE}">FF4J - Home</title>
-    
+
   </head>
-  
+
 <body>Sample</body>
 </html>
 

--- a/ff4j-web/src/main/resources/views/view-home.html
+++ b/ff4j-web/src/main/resources/views/view-home.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:th="http://www.thymeleaf.org">
-<head th:include="header :: head"></head>
+<head th:insert="~{header :: head}"></head>
 <body>
 
-	<div class="navbar navbar-fixed-top" th:include="navbar :: navbar"></div>
+	<div class="navbar navbar-fixed-top" th:insert="~{navbar :: navbar}"></div>
 
-	<div class="subnavbar" th:include="navbar :: subnavbar"></div>
+	<div class="subnavbar" th:insert="~{navbar :: subnavbar}"></div>
 
 	<div id="wrapper" class="container">
 		<div class="row">
@@ -16,7 +16,7 @@
 						<div class="container">
 
 
-							<div th:include="messages :: messagebar" style="margin-top: 60px"></div>
+							<div th:insert="~{messages :: messagebar}" style="margin-top: 60px"></div>
 
 							<div class="row">
 								<div class="span6">
@@ -172,13 +172,13 @@
 													class="shortcut-icon icon-upload-alt"></i> <span
 													class="shortcut-label" th:text="#{home.admin.import}">Import</span>
 												</a>
-												
+
 												<a data-toggle="modal" href="#modalExport"
 													class="shortcut open-ExportDialog"> <i
 													class="shortcut-icon icon-download-alt"></i> <span
 													class="shortcut-label" th:text="#{home.admin.export}">Export</span>
 												</a>
-												
+
 												<a data-toggle="modal" href="#modalCreateSchema"
 													class="shortcut"> <i class="shortcut-icon icon-table"></i>
 													<span class="shortcut-label"
@@ -208,11 +208,11 @@
 		</div>
 	</div>
 
-	<div th:include="modal-features :: modal-import"></div>
-	<div th:include="modal-features :: modal-export"></div>
+	<div th:insert="~{modal-features :: modal-import}"></div>
+	<div th:insert="~{modal-features :: modal-export}"></div>
 
-	<div th:include="modal-home :: modal-createSchema"></div>
-	<div th:include="modal-home :: modal-clearCache"></div>
+	<div th:insert="~{modal-home :: modal-createSchema}"></div>
+	<div th:insert="~{modal-home :: modal-clearCache}"></div>
 
 
 </body>

--- a/ff4j-web/src/main/resources/views/view-infos.html
+++ b/ff4j-web/src/main/resources/views/view-infos.html
@@ -1,31 +1,31 @@
 <!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:include="header :: head"></head>
+<head th:insert="~{header :: head}"></head>
 <body>
-  
-<div class="navbar navbar-fixed-top" th:include="navbar :: navbar"></div>
 
-<div class="subnavbar" th:include="navbar :: subnavbarback"></div>
+<div class="navbar navbar-fixed-top" th:insert="~{navbar :: navbar}"></div>
+
+<div class="subnavbar" th:insert="~{navbar :: subnavbarback}"></div>
 
 <div id="wrapper" class="container" >
  <div class="row">
-  <div class="span9"> 
+  <div class="span9">
    <div id="content" class="clearfix" >
     <div class="main-inner" style="margin-top:60px">
      <div class="container">
-     
+
       <div class="row">
         <div class="span6">
-        
+
           <!--  General Informations -->
           <div class="widget widget-nopad">
             <div class="widget-header">
               <i class="icon-wrench"></i>
               <h3><span th:text="#{infos.techs.title}">A-Z DataStore</span></h3>
             </div>
-           
+
   <div class="widget-content">
-          		
+
     <div class="ff4jstores">
 	   <div class="ff4jstore" >
         <span style="font-weight:bold;font-size:14px;color:#8b8b8b">&nbsp;NoSQL</span>
@@ -230,7 +230,7 @@
   </div>
 
   <div class="span6">
-   
+
    <div class="widget">
     <div class="widget-header">
      <i class="icon-envelope-alt"></i>
@@ -239,27 +239,27 @@
     <div class="widget-content">
       <p style="font-size:16px;color:#00008b">
         <i class="icon-globe"></i>&nbsp;&nbsp;
-        <a href="ff4j.org">ff4j.org</a> 
+        <a href="ff4j.org">ff4j.org</a>
         is the official website where you'll find any documentation and informations.
       </p>
       <p style="font-size:16px;color:#8b8b8b">
-       <i class="icon-github"></i>&nbsp;&nbsp;The framework is hosted and maintained on 
-       <a href="https://github.com/clun/ff4j">github</a>, you can browse and fork the source code. 
+       <i class="icon-github"></i>&nbsp;&nbsp;The framework is hosted and maintained on
+       <a href="https://github.com/clun/ff4j">github</a>, you can browse and fork the source code.
        Please consider adding a STAR <i class="icon-star"></i> if you like, it helps making the framework well known.
 	 </p>
-	<p style="font-size:16px;color:#00008b">			   
-	  <i class="icon-question-sign"></i>&nbsp;&nbsp;If you have any question you can either 
-	  <a href="https://github.com/ff4j/ff4j/issues">open  a ticket in github</a> 
+	<p style="font-size:16px;color:#00008b">
+	  <i class="icon-question-sign"></i>&nbsp;&nbsp;If you have any question you can either
+	  <a href="https://github.com/ff4j/ff4j/issues">open  a ticket in github</a>
 	  or join us to chat <a href="https://discord.gg/svu3akK"> on discord </a>.
 	</p>
 	<p style="font-size:16px;color:#8b8b8b">
         <i class="icon-twitter"></i>&nbsp;&nbsp;
-        If you like FF4J, please follow me <a href="https://twitter.com/clunven">@clunven</a> 
+        If you like FF4J, please follow me <a href="https://twitter.com/clunven">@clunven</a>
         and use <a href="https://twitter.com/hashtag/ff4j?src=hash">#ff4j</a> hashtag to share your feedbacks
      </p>
    </div>
   </div>
-            
+
   <div class="widget">
             <div class="widget-header">
               <i class="icon-heart-empty"></i>
@@ -271,43 +271,43 @@
              The FF4J team has been working very hard to provide a powerful <span style="color:#00ab8b">Feature Toggle solution</span> which is stable, highly tested, as well as easy to configure and use.
 			 We always make every effort to respond to all support and request queries in a timely manner and work with users to help resolve their problems quickly.
 			 All of this requires a surprising amount of time.</p>
-			 
+
 			 <p style="text-align:justify">As open source application, it is free and <span style="color:#00ab8b">will always remain free.</span>
-			 However, if you enjoy using <b>ff4j</b> or find that it is improving the value of a product or service that 
+			 However, if you enjoy using <b>ff4j</b> or find that it is improving the value of a product or service that
 			 your organization provides, we urge you to consider donating.</p>
-             
+
              <p>
 	             <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
 					<input type="hidden" name="cmd" value="_s-xclick" />
 					<input type="hidden" name="hosted_button_id" value="XD2BQ9KDJ7SGU" />
-					<input type="image" 
+					<input type="image"
 						th:src="@{static/img/btn_donate_LG.gif}"
 						src="https://www.paypalobjects.com/en_GB/i/btn/btn_donate_LG.gif"
 						 border="0" name="submit" alt="Donate to FF4J" />
-					<img alt="" border="0" 
-						src="https://www.paypalobjects.com/fr_FR/i/scr/pixel.gif" width="1" height="1" 
+					<img alt="" border="0"
+						src="https://www.paypalobjects.com/fr_FR/i/scr/pixel.gif" width="1" height="1"
 						th:src="@{static/img/pixel.gif}"/>
 				 </form>
 			 </p>
 
             </div>
-            
+
             </div>
-            
-           
-            
+
+
+
             </div>
-          
-          
-          
+
+
+
           </div><!-- ROW -->
-          
+
 	 </div>
 	</div>
    </div>
   </div>
  </div>
 </div>
-   
+
 </body>
 </html>

--- a/ff4j-web/src/main/resources/views/view-messages.html
+++ b/ff4j-web/src/main/resources/views/view-messages.html
@@ -2,8 +2,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
 <body>
 
-<div th:fragment="messagebar">
- 
+<th:block th:fragment="messagebar">
+
  <div th:if="${msgInfo} != null">
   <div class="alert" th:class="'alert alert-' + ${msgType}" style="margin-left:50px;margin-right:20px">
    <button type="button" class="close" data-dismiss="alert">&times;</button>
@@ -11,8 +11,8 @@
   </div>
  </div>
  <div id="message" >&nbsp;</div>
- 
-</div>
-    
+
+</th:block>
+
 </body>
 </html>

--- a/ff4j-web/src/main/resources/views/view-modal-features.html
+++ b/ff4j-web/src/main/resources/views/view-modal-features.html
@@ -2,12 +2,12 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
 <body>
 
-<div th:fragment="modal-import">
+<th:block th:fragment="modal-import">
  <form class="form-horizontal" action="" th:action="@{home}" method="POST" enctype="multipart/form-data" >
-  <div class="modal hide fade" id="modalImport" tabindex="-1" role="dialog" 
+  <div class="modal hide fade" id="modalImport" tabindex="-1" role="dialog"
   	   aria-labelledby="myModalLabel" aria-hidden="true">
-    <div class="modal-header">   
-      <button class="close" data-dismiss="modal">x</button>   
+    <div class="modal-header">
+      <button class="close" data-dismiss="modal">x</button>
       <h4 id="myModalLabel"><i class="icon-upload-alt"></i>&nbsp;
       <span th:text="#{modal.import.title}" >Import </span></h4>
     </div>
@@ -28,27 +28,27 @@
     </div>
   </div>
 </form>
-</div>
+</th:block>
 
-<div th:fragment="modal-export">
-  <div class="modal hide fade" id="modalExport" tabindex="-1" role="dialog" 
+<th:block th:fragment="modal-export">
+  <div class="modal hide fade" id="modalExport" tabindex="-1" role="dialog"
   	   aria-labelledby="myModalLabele" aria-hidden="true">
-    <div class="modal-header">   
-      <button class="close" data-dismiss="modal">x</button>   
+    <div class="modal-header">
+      <button class="close" data-dismiss="modal">x</button>
       <h4 id="myModalLabel"><i class="icon-download-alt"></i>&nbsp;
       <span th:text="#{modal.export.title}" >Export </span></h4>
     </div>
     <div class="modal-body">
      <div class="shortcuts">
-	   <a href="" th:href="@{api/export/xml}" class="shortcut"> 
+	   <a href="" th:href="@{api/export/xml}" class="shortcut">
 	    <i class="shortcut-icon icon-download-alt" style="color:#880000"></i>
 	    <span class="shortcut-label" >XML</span>
 	   </a>
-	   <a href="" th:href="@{api/export/yml}" class="shortcut" > 
+	   <a href="" th:href="@{api/export/yml}" class="shortcut" >
 	    <i class="shortcut-icon icon-download-alt" style="color:#008800"></i>
 	    <span class="shortcut-label">YAML</span>
 	   </a>
-	   <a href="" th:href="@{api/export/properties}" class="shortcut" > 
+	   <a href="" th:href="@{api/export/properties}" class="shortcut" >
 	    <i class="shortcut-icon icon-download-alt" style="color:#000088"></i>
 	    <span class="shortcut-label">PROPERTIES</span>
 	   </a>
@@ -61,48 +61,48 @@
        </button>
     </div>
   </div>
-</div>
+</th:block>
 
-<div th:fragment="modal-edit">
+<th:block th:fragment="modal-edit">
 
 <form class="form-horizontal" th:action="@{features}" action="" method="POST" >
-  <div class="modal hide fade" id="modalEdit" 
-        tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">    
+  <div class="modal hide fade" id="modalEdit"
+        tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
     <div class="modal-header">
       <button class="close" data-dismiss="modal">x</button>
       <h4 id="myModalLabel">
       <i class="icon-pencil"></i>&nbsp;
       <span th:text="#{modal.editfeature.title}" >Edit Feature</span></h4>
     </div>
-    
+
   <!-- Body -->
-  <div class="modal-body" style="height:500px;">    
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px"> 
-      <label class="control-label" for="uid" 
+  <div class="modal-body" style="height:500px;">
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
+      <label class="control-label" for="uid"
              style="color:#687684;font-style:normal;font-weight:normal;"
              th:text="#{modal.createfeature.featurename}" >Feature Name</label>
-      <div class="controls">   
-        <input type="text" name="uid" id="uid" 
-            style="width:350px;height:18px;color:#008bab;background-color:white" required="required" readonly="true"/>  
+      <div class="controls">
+        <input type="text" name="uid" id="uid"
+            style="width:350px;height:18px;color:#008bab;background-color:white" required="required" readonly="true"/>
       </div>
     </div>
 
-    <!-- Description --> 
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">   
-      <label class="control-label" for="desc" 
+    <!-- Description -->
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
+      <label class="control-label" for="desc"
              style="color:#687684;font-style:normal"
-             th:text="#{modal.createfeature.description}" >Description</label>  
+             th:text="#{modal.createfeature.description}" >Description</label>
       <div class="controls">
         <textarea class="field span4" style="width:350px;color:#008bab"
             name="desc" id="desc" rows="2" cols="30"></textarea>
       </div>
     </div>
 
-    <!-- Group --> 
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">   
+    <!-- Group -->
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
       <label class="control-label" for="group"
              style="color:#687684;font-style:normal"
-             th:text="#{modal.editfeature.group}" >Group</label>  
+             th:text="#{modal.editfeature.group}" >Group</label>
         <div class="controls">
           <div class="btn-group">
             <input type="text" name="groupName" id="groupName" style="width:350px;height:18px;color:#008bab" />
@@ -119,15 +119,15 @@
                <li class="divider"></li>
               <li><a href="#" onclick="javascript:$('#groupName').val('');">None</a></li>
             </ul>
-          </div> <!-- btn-group -->     
+          </div> <!-- btn-group -->
         </div> <!-- controls -->
       </div> <!-- control-group -->
 
-    <!-- Strategy --> 
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">   
-      <label class="control-label" for="strategy" 
+    <!-- Strategy -->
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
+      <label class="control-label" for="strategy"
              style="color:#687684;font-style:normal"
-             th:text="#{modal.editfeature.strategy}" >Strategy</label>  
+             th:text="#{modal.editfeature.strategy}" >Strategy</label>
       <div class="controls">
         <div class="btn-group">
             <input type="text" name="strategy" id="strategy" style="width:350px;height:18px;font-style:normal;color:#008bab" />
@@ -192,19 +192,19 @@
          </tbody>
         </table>
       </div>
-      
-        
-        
+
+
+
       </div>
 
-    <!-- Permissions --> 
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">   
-      <label class="control-label" for="permission" 
+    <!-- Permissions -->
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
+      <label class="control-label" for="permission"
              style="color:#687684;font-style:normal"
-             th:text="#{modal.editfeature.permissions}" >Permissions</label>  
+             th:text="#{modal.editfeature.permissions}" >Permissions</label>
       <div class="controls">
         <div class="btn-group">
-            <input type="text" name="permission" id="permission" style="width:350px;height:18px;font-style:normal;color:#008bab" 
+            <input type="text" name="permission" id="permission" style="width:350px;height:18px;font-style:normal;color:#008bab"
             value="Public" readonly="readonly" />
             <button type="button" class="btn btn-green dropdown-toggle" data-toggle="dropdown" style="float:right;margin-left:-5px">
               <span class="caret"></span>
@@ -224,11 +224,11 @@
          </tbody>
         </table>
       </div>
-     </div><!-- Control group -->     
-     
-    <!-- Properties --> 
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">   
-      <label class="control-label" for="properties" style="color:#00ab8b;font-style:normal">Properties</label>  
+     </div><!-- Control group -->
+
+    <!-- Properties -->
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
+      <label class="control-label" for="properties" style="color:#00ab8b;font-style:normal">Properties</label>
       <div class="controls"  id="propertyList">
         <table class="table table-bordered table-condensed" style="margin-top:8px;width:345px">
          <tbody id="modalEditFeatureProperties">
@@ -236,9 +236,9 @@
         </table>
       </div>
      </div><!-- Control group -->
-     
+
     </div> <!-- Modal-body -->
-    
+
     <div class="modal-footer" >
     <button class="btn btn" data-dismiss="modal">
       <i class="icon-remove" ></i>&nbsp;
@@ -248,7 +248,7 @@
       <i class="icon-ok icon-white" ></i>&nbsp;
       <span th:text="#{modal.button.validate}">Validate</span></button>
     </div>
-      
+
     <input type="hidden" name="op" value="update"  />
   </div>
 </form>
@@ -257,19 +257,19 @@
  $(document).on("click", ".open-EditFlipDialog", function () {
 	 ff4j_updateModalEditFeature($(this).data('id'));
  });
- 
+
 </script>
 
-</div>
+</th:block>
 
 <!-- --------------------------------------------- -->
 <!-- Fragment - Modal to create a new feature      -->
 <!-- --------------------------------------------- -->
-<div th:fragment="modal-create">
+<th:block th:fragment="modal-create">
 
 <!-- Creation FORM -->
 <form class="form-horizontal" th:action="@{features}" action="" method="POST" >
- <div class="modal hide fade" id="modalCreate" tabindex="-1" 
+ <div class="modal hide fade" id="modalCreate" tabindex="-1"
        role="dialog" aria-labelledby="labelCreate" aria-hidden="true">
    <div class="modal-header">
       <button class="close" data-dismiss="modal">x</button>
@@ -277,29 +277,29 @@
       <i class="icon-file"></i>&nbsp;
       <span th:text="#{modal.createfeature.title}" >Create Feature</span></h4>
    </div>
-   
+
   <!-- Body -->
-  <div class="modal-body" style="height:150px;">    
-    
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px"> 
-      <label class="control-label" for="uid" 
+  <div class="modal-body" style="height:150px;">
+
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
+      <label class="control-label" for="uid"
         style="color:#687684;font-style:normal;font-weight:normal;" th:text="#{modal.createfeature.featurename}" >Feature Name</label>
-      <div class="controls">   
-        <input type="text" name="uid" id="uid" 
-            style="width:350px;height:18px;color:#008bab;background-color:white" required="required" />  
+      <div class="controls">
+        <input type="text" name="uid" id="uid"
+            style="width:350px;height:18px;color:#008bab;background-color:white" required="required" />
       </div>
     </div>
-   
-   <!-- Description --> 
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">   
-      <label class="control-label" for="desc" style="color:#687684;font-style:normal" th:text="#{modal.createfeature.description}">Description</label>  
+
+   <!-- Description -->
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
+      <label class="control-label" for="desc" style="color:#687684;font-style:normal" th:text="#{modal.createfeature.description}">Description</label>
       <div class="controls">
         <textarea class="field span4" style="width:350px;color:#008bab"
             name="desc" id="desc" rows="2" cols="30"></textarea>
       </div>
     </div>
 
-    <!-- Message --> 
+    <!-- Message -->
     <div class="control-group" style="margin-left:50px;float:left">
      <span style="color:#008bab;font-style:italic" th:text="#{modal.createfeature.comment}">
        Once created, you will access all attributes through edit button
@@ -327,40 +327,40 @@
  </div>
 </form>
 
-</div>
+</th:block>
 
 <!-- --------------------------------------------- -->
 <!-- Fragment - Modal to ask for feature deleting  -->
 <!-- --------------------------------------------- -->
-<div th:fragment="modal-deleteFeature">
+<th:block th:fragment="modal-deleteFeature">
   <form class="form-horizontal" th:action="@{features}" action="" method="POST" >
-    <div class="modal hide fade" 
-         id="modalDeleteFeature" 
-         tabindex="-1" 
-         role="dialog" 
-         aria-labelledby="modalDeleteFeatureLabel" 
+    <div class="modal hide fade"
+         id="modalDeleteFeature"
+         tabindex="-1"
+         role="dialog"
+         aria-labelledby="modalDeleteFeatureLabel"
          aria-hidden="true">
      <input type="hidden" name="op" value="delete"  />
-     <div class="modal-header"> 
-       <button class="close" data-dismiss="modal">x</button>   
+     <div class="modal-header">
+       <button class="close" data-dismiss="modal">x</button>
         <h4 id="modalDeleteFeatureLabel"><i class="icon-trash"></i>&nbsp;
         <span th:text="#{modal.deletefeature.title}" >Delete feature</span></h4>
      </div>
     <div class="modal-body">
 	  <div class="control-group" style="margin-left:50px;float:left">
-	    <span style="color:#ab0000;font-weight:bold" 
+	    <span style="color:#ab0000;font-weight:bold"
 	    	  th:text="#{modal.deletefeature.confirmMessage}">
 	         Are you sure you want to delete this feature ?
 	    </span>
 	  </div>
-      <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px"> 
-        <label class="control-label" for="uid" 
-               style="color:#687684;font-style:normal;font-weight:normal;" 
+      <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
+        <label class="control-label" for="uid"
+               style="color:#687684;font-style:normal;font-weight:normal;"
                th:text="#{modal.createfeature.featurename}">Feature Named</label>
-        <div class="controls">   
-          <input type="text" name="uid" id="uid" 
-               style="width:350px;height:18px;color:#008bab;background-color:white" 
-               readonly="true" />  
+        <div class="controls">
+          <input type="text" name="uid" id="uid"
+               style="width:350px;height:18px;color:#008bab;background-color:white"
+               readonly="true" />
         </div>
       </div>
    </div>
@@ -381,34 +381,34 @@
 	 ff4j_updateModalDeleteFeature($(this).data('id'));
    });
  </script>
-</div>
+</th:block>
 
 <!-- --------------------------------------------- -->
 <!-- Fragment - Modal to toggle a group Feature    -->
 <!-- --------------------------------------------- -->
-<div th:fragment="modal-toggle">
+<th:block th:fragment="modal-toggle">
   <form class="form-horizontal" th:action="@{features}" action="" method="POST" >
-    <div class="modal hide fade" 
-         id="modalToggle" tabindex="-1" 
-         role="dialog" 
-         aria-labelledby="myModalLabel" 
+    <div class="modal hide fade"
+         id="modalToggle" tabindex="-1"
+         role="dialog"
+         aria-labelledby="myModalLabel"
          aria-hidden="true">
-     <div class="modal-header">   
-      <button class="close" data-dismiss="modal">x</button>   
+     <div class="modal-header">
+      <button class="close" data-dismiss="modal">x</button>
       <h4 id="myModalLabel">
       <i class="icon-th-list icon-white"></i>&nbsp;
       <span th:text="#{modal.togglegroup.title}" > Toggle a group of features</span>
       </h4>
      </div>
      <div class="modal-body" style="height:120px">
-       <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">   
+       <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
          <label class="control-label" for="group" style="color:#687684;font-style:normal">
            <span th:text="#{modal.togglegroup.list}" >Toggle a group of features</span>
-         </label>  
+         </label>
          <div class="controls">
           <div class="btn-group">
             <input type="text" name="groupName" id="groupName" style="width:350px;height:18px;color:#008bab" />
-            <button type="button" class="btn btn-green dropdown-toggle" 
+            <button type="button" class="btn btn-green dropdown-toggle"
             		data-toggle="dropdown" style="float:right;margin-left:-5px">
               <span class="caret"></span>
               <span class="sr-only"><i class="icon-inbox icon-white" ></i></span>
@@ -425,16 +425,16 @@
           </div> <!-- btn-group -->
         </div> <!-- controls -->
       </div> <!-- control-group -->
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">   
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
       <label class="control-label" for="ope" style="color:#687684;font-style:normal">
        <span th:text="#{modal.togglegroup.operation}" >Operation</span>
-      </label>  
+      </label>
       <div class="controls">
         <div class="btn-group">
-            <input type="text" name="ope" id="ope" 
+            <input type="text" name="ope" id="ope"
             	   style="width:350px;height:18px;color:#008bab;background-color:white" readonly="readonly" />
-            <button type="button" class="btn btn-green dropdown-toggle" 
-            		data-toggle="dropdown" 
+            <button type="button" class="btn btn-green dropdown-toggle"
+            		data-toggle="dropdown"
             		style="float:right;margin-left:-5px">
               <span class="caret"></span>
               <span class="sr-only"><i class="icon-cog icon-white" ></i></span>
@@ -459,28 +459,28 @@
    <input type="hidden" name="op" value="toggleGroup"  />
   </div>
 </form>
-</div>
+</th:block>
 
 <!-- --------------------------------------------- -->
 <!-- Fragment - Modal to rename a Feature          -->
 <!-- --------------------------------------------- -->
-<div th:fragment="modal-rename">
+<th:block th:fragment="modal-rename">
  <form class="form-horizontal" th:action="@{features}" action="" method="POST" >
 
-  <div class="modal hide fade" id="modalRenameFeature" tabindex="-1" 
+  <div class="modal hide fade" id="modalRenameFeature" tabindex="-1"
        role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-    <div class="modal-header">   
-      <button class="close" data-dismiss="modal">x</button>   
+    <div class="modal-header">
+      <button class="close" data-dismiss="modal">x</button>
       <h4 id="myModalLabel">
       <i class="icon-th-list icon-white"></i>&nbsp;
       <span th:text="#{modal.renamefeature.title}" >Rename Feature</span>
       </h4>
     </div>
     <div class="modal-body" style="height:120px">
-     <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">   
+     <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
       <label class="control-label" for="group" style="color:#687684;font-style:normal">
         <span th:text="#{modal.renamefeature.list}" >Feature List</span>
-      </label> 
+      </label>
         <div class="controls">
           <div class="btn-group">
             <input type="text" name="uid" id="uid" style="width:350px;height:18px;color:#008bab" />
@@ -495,19 +495,19 @@
                 </a>
                </li>
             </ul>
-          </div> <!-- btn-group -->     
+          </div> <!-- btn-group -->
         </div> <!-- controls -->
-      </div> <!-- control-group -->      
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px"> 
-      <label class="control-label" for="uid" 
+      </div> <!-- control-group -->
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
+      <label class="control-label" for="uid"
         style="color:#687684;font-style:normal;font-weight:normal;" th:text="#{modal.renamefeature.new}" >New Name </label>
-      <div class="controls">   
-        <input type="text" name="newname" id="newname" 
-            style="width:350px;height:18px;color:#008bab;background-color:white" required="required" />  
+      <div class="controls">
+        <input type="text" name="newname" id="newname"
+            style="width:350px;height:18px;color:#008bab;background-color:white" required="required" />
       </div>
-    </div> 
     </div>
-    
+    </div>
+
      <div class="modal-footer" >
     <button class="btn btn" data-dismiss="modal">
       <i class="icon-remove" ></i>&nbsp;
@@ -517,27 +517,27 @@
       <i class="icon-ok icon-white" ></i>&nbsp;
       <span th:text="#{modal.button.validate}">Validate</span></button>
   </div>
-    
+
    <input type="hidden" name="op" value="renameFeature"  />
 
   </div>
 </form>
 
 
-</div>
+</th:block>
 
 <!-- ******************** -->
 <!-- MODAL COPY FEATURE -->
 <!-- ******************** -->
-<div th:fragment="modal-copy">
+<th:block th:fragment="modal-copy">
 
 <form class="form-horizontal" th:action="@{features}" action="" method="POST" >
 
-  <div class="modal hide fade" id="modalCopyFeature" tabindex="-1" 
+  <div class="modal hide fade" id="modalCopyFeature" tabindex="-1"
        role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-    
-    <div class="modal-header">   
-      <button class="close" data-dismiss="modal">x</button>   
+
+    <div class="modal-header">
+      <button class="close" data-dismiss="modal">x</button>
       <h4 id="myModalLabel">
       <i class="icon-th-list icon-white"></i>&nbsp;
       <span th:text="#{modal.copyfeature.title}" >Copy Feature</span>
@@ -545,11 +545,11 @@
     </div>
 
     <div class="modal-body" style="height:120px">
-    
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">   
+
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
       <label class="control-label" for="group" style="color:#687684;font-style:normal">
         <span th:text="#{modal.copyfeature.list}" >Feature List</span>
-      </label> 
+      </label>
         <div class="controls">
           <div class="btn-group">
             <input type="text" name="uid" id="uid" style="width:350px;height:18px;color:#008bab" />
@@ -564,19 +564,19 @@
                 </a>
                </li>
             </ul>
-          </div> <!-- btn-group -->     
+          </div> <!-- btn-group -->
         </div> <!-- controls -->
-      </div> <!-- control-group -->      
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px"> 
-      <label class="control-label" for="uid" 
+      </div> <!-- control-group -->
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
+      <label class="control-label" for="uid"
         style="color:#687684;font-style:normal;font-weight:normal;" th:text="#{modal.copyfeature.new}" >New Name </label>
-      <div class="controls">   
-        <input type="text" name="newname" id="newname" 
-            style="width:350px;height:18px;color:#008bab;background-color:white" required="required" />  
+      <div class="controls">
+        <input type="text" name="newname" id="newname"
+            style="width:350px;height:18px;color:#008bab;background-color:white" required="required" />
       </div>
-    </div> 
     </div>
-    
+    </div>
+
      <div class="modal-footer" >
     <button class="btn btn" data-dismiss="modal">
       <i class="icon-remove" ></i>&nbsp;
@@ -586,17 +586,17 @@
       <i class="icon-ok icon-white" ></i>&nbsp;
       <span th:text="#{modal.button.validate}">Validate</span></button>
   </div>
-    
+
    <input type="hidden" name="op" value="copyFeature"  />
 
   </div>
 </form>
 
 
-</div>
+</th:block>
 
 
 
-    
+
 </body>
 </html>

--- a/ff4j-web/src/main/resources/views/view-modal-home.html
+++ b/ff4j-web/src/main/resources/views/view-modal-home.html
@@ -3,12 +3,12 @@
 <body>
 
 
- <div th:fragment="modal-createSchema">
+ <th:block th:fragment="modal-createSchema">
  <form class="form-horizontal" action="" th:action="@{home}" method="POST"  >
-  <div class="modal hide fade" id="modalCreateSchema" tabindex="-1" role="dialog" 
+  <div class="modal hide fade" id="modalCreateSchema" tabindex="-1" role="dialog"
   	   aria-labelledby="myModalLabel" aria-hidden="true">
-    <div class="modal-header">   
-      <button class="close" data-dismiss="modal">x</button>   
+    <div class="modal-header">
+      <button class="close" data-dismiss="modal">x</button>
       <h4 id="myModalLabel"><i class="icon-upload-alt"></i>&nbsp;
       <span th:text="#{modal.createschema.title}" >Create Schema</span></h4>
     </div>
@@ -28,9 +28,9 @@
     </div>
   </div>
 </form>
-</div>
+ </th:block>
 
- <div th:fragment="modal-clearCache">
+ <th:block th:fragment="modal-clearCache">
      <form class="form-horizontal" action="" th:action="@{home}" method="POST"  >
          <div class="modal hide fade" id="modalClearCache" tabindex="-1" role="dialog"
               aria-labelledby="myModalLabel" aria-hidden="true">
@@ -55,7 +55,7 @@
              </div>
          </div>
      </form>
- </div>
-    
+ </th:block>
+
 </body>
 </html>

--- a/ff4j-web/src/main/resources/views/view-modal-properties.html
+++ b/ff4j-web/src/main/resources/views/view-modal-properties.html
@@ -5,16 +5,16 @@
 <!-- *********************** -->
 <!--  FORM CREATE PROPERTY   -->
 <!-- *********************** -->
-<div th:fragment="modal-createProperty">
- 
-<form id="createPropertyForm" 
-      class="form-horizontal" th:action="@{properties}" 
-      action="" 
+<th:block th:fragment="modal-createProperty">
+
+<form id="createPropertyForm"
+      class="form-horizontal" th:action="@{properties}"
+      action=""
       method="POST" >
-    
- <div class="modal hide fade" id="modalCreateProperty" tabindex="-1" role="dialog" 
+
+ <div class="modal hide fade" id="modalCreateProperty" tabindex="-1" role="dialog"
     aria-labelledby="labelCreateProperty" aria-hidden="true">
-  
+
   <div class="modal-header">
       <button class="close" data-dismiss="modal">x</button>
       <h4 id="labelCreateProperty">
@@ -24,44 +24,44 @@
 
   <!-- Body -->
   <div class="modal-body" style="height:280px">
-  
+
     <input type="hidden" name="op" value="createProperty"  />
-    
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px" id="createPropertyFeatureControlGroup" > 
-      <label class="control-label" for="name" style="color:#687684;font-style:normal;font-weight:normal;" 
+
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px" id="createPropertyFeatureControlGroup" >
+      <label class="control-label" for="name" style="color:#687684;font-style:normal;font-weight:normal;"
         th:text="#{modal.createproperty.featureid}" >FeatureName</label>
       <div class="controls">
-        <input type="text" name="featureid" id="featureid" 
-               style="width:350px;height:18px;color:#00ab8b;background-color:white" readonly="readonly"/>  
+        <input type="text" name="featureid" id="featureid"
+               style="width:350px;height:18px;color:#00ab8b;background-color:white" readonly="readonly"/>
       </div>
     </div>
-    
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px"> 
-      <label class="control-label" for="name" style="color:#687684;font-style:normal;font-weight:normal;" 
+
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
+      <label class="control-label" for="name" style="color:#687684;font-style:normal;font-weight:normal;"
         th:text="#{modal.createproperty.propertyname}" >Property Name</label>
-      <div class="controls">   
-        <input type="text" name="name" id="name" style="width:350px;height:18px;color:#008bab;background-color:white" required="required" />  
+      <div class="controls">
+        <input type="text" name="name" id="name" style="width:350px;height:18px;color:#008bab;background-color:white" required="required" />
       </div>
     </div>
-    
-    <!-- Description --> 
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">   
+
+    <!-- Description -->
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
       <label class="control-label" for="pDesc" style="color:#687684;font-style:normal"
-             th:text="#{modal.createproperty.description}">Description</label>  
+             th:text="#{modal.createproperty.description}">Description</label>
       <div class="controls">
         <textarea class="field span4" style="width:350px;color:#008bab"
             name="desc" id="pDesc" rows="2" cols="30"></textarea>
       </div>
     </div>
-    
-    <!-- Type --> 
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">  
-      <label class="control-label" for="pType" style="color:#687684;font-style:normal" 
+
+    <!-- Type -->
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
+      <label class="control-label" for="pType" style="color:#687684;font-style:normal"
             th:text="#{modal.createproperty.type}" >Type</label>
       <div class="controls" >
         <div class="btn-group">
             <input type="text" name="pType" id="pType" style="width:350px;height:18px;color:#008bab;background-color:white"/>
-            <button type="button" class="btn btn-green dropdown-toggle" data-toggle="dropdown" 
+            <button type="button" class="btn btn-green dropdown-toggle" data-toggle="dropdown"
                     style="float:right;margin-left:-5px">
               <span class="caret"></span>
               <span class="sr-only"><i class="icon-cog icon-white" ></i></span>
@@ -81,26 +81,26 @@
          </div>
        </div>
     </div>
-  
-    <!-- Value --> 
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px"> 
-      <label class="control-label" for="pValue" 
-             style="color:#687684;font-style:normal;font-weight:normal;" 
+
+    <!-- Value -->
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
+      <label class="control-label" for="pValue"
+             style="color:#687684;font-style:normal;font-weight:normal;"
              th:text="#{modal.createproperty.value}" >Value</label>
-      <div class="controls">   
-        <input type="text" name="pValue" id="pValue" 
-               style="width:350px;height:18px;color:#008bab;background-color:white" 
-               required="required" />  
+      <div class="controls">
+        <input type="text" name="pValue" id="pValue"
+               style="width:350px;height:18px;color:#008bab;background-color:white"
+               required="required" />
       </div>
     </div>
-    
-    <!-- Message --> 
+
+    <!-- Message -->
     <div class="control-group" style="margin-left:50px;float:left">
      <span style="color:#008bab;font-style:italic" th:text="#{modal.createproperty.comment}">
        Please add fixedValues once the property is created
      </span>
     </div>
-     
+
   </div> <!-- modal body -->
 
   <div class="modal-footer" >
@@ -112,49 +112,49 @@
       <i class="icon-ok icon-white" ></i>&nbsp;
       <span th:text="#{modal.button.create}">Create</span></button>
   </div>
- 
+
  </div>
 </form>
- 
- </div>
+
+</th:block>
 
 <!-- ************************* -->
 <!--  DELETE PROPERTY MODAL    -->
 <!-- ************************* -->
- <div th:fragment="modal-deleteProperty">
+ <th:block th:fragment="modal-deleteProperty">
  <form class="form-horizontal" th:action="@{properties}" action="" method="POST" >
-  <div class="modal hide fade" id="modalDeleteProperty" tabindex="-1" role="dialog" 
+  <div class="modal hide fade" id="modalDeleteProperty" tabindex="-1" role="dialog"
        aria-labelledby="modalDeletePropertyLabel" aria-hidden="true">
-    
+
     <input type="hidden" name="op" value="deleteProperty"  />
-    
-    <div class="modal-header"> 
-      <button class="close" data-dismiss="modal">x</button>   
+
+    <div class="modal-header">
+      <button class="close" data-dismiss="modal">x</button>
       <h4 id="modalDeletePropertyLabel"><i class="icon-trasht"></i>&nbsp;
       <span th:text="#{modal.deleteproperty.title}" >Delete Property</span></h4>
     </div>
-    
+
     <div class="modal-body">
-     
-       <!-- Message --> 
+
+       <!-- Message -->
         <div class="control-group" style="margin-left:0px;float:left">
          <span style="color:#ab0000;font-weight:bold" th:text="#{modal.deleteproperty.confirmMessage}">
              Are you sure you want to delete this Property ?
          </span>
         </div>
-    
-       <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px"> 
+
+       <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
         <label class="control-label" for="name"
-               style="color:#687684;font-style:normal;font-weight:normal;" 
+               style="color:#687684;font-style:normal;font-weight:normal;"
                th:text="#{modal.createproperty.propertyname}" >Property Name</label>
-        <div class="controls">   
-        <input type="text" name="name" id="name" 
-               style="width:350px;height:18px;color:#008bab;background-color:white" 
-               readonly="true" />  
+        <div class="controls">
+        <input type="text" name="name" id="name"
+               style="width:350px;height:18px;color:#008bab;background-color:white"
+               readonly="true" />
        </div>
      </div>
     </div>
-    
+
     <div class="modal-footer">
       <button class="btn btn" data-dismiss="modal">
         <i class="icon-remove" ></i>
@@ -167,68 +167,68 @@
     </div>
   </div>
   </form>
-</div>
+ </th:block>
 
 <!-- *********************** -->
 <!--  FORM UPDATE PROPERTY   -->
 <!-- *********************** -->
 
-<div th:fragment="modal-updateProperty">
+<th:block th:fragment="modal-updateProperty">
 
-<form id="updatePropertyForm" 
+<form id="updatePropertyForm"
       class="form-horizontal" th:action="@{properties}" action="" method="POST" >
- 
- <div class="modal hide fade" id="modalEditProperty" 
+
+ <div class="modal hide fade" id="modalEditProperty"
       tabindex="-1" role="dialog" aria-hidden="true">
-     
+
    <div class="modal-header">
      <button class="close" data-dismiss="modal">x</button>
      <h4 id="myModalLabel">
      <i class="icon-pencil"></i>&nbsp;
      <span th:text="#{modal.editproperty.title}" >Edit Property</span></h4>
    </div>
-    
+
    <div class="modal-body" style="height:500px">
-   
+
    <input type="hidden" name="op" value="updateProperty"  />
-   
-   <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px" id="updatePropertyFeatureControlGroup" > 
-      <label class="control-label" for="name" style="color:#687684;font-style:normal;font-weight:normal;" 
+
+   <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px" id="updatePropertyFeatureControlGroup" >
+      <label class="control-label" for="name" style="color:#687684;font-style:normal;font-weight:normal;"
         th:text="#{modal.editproperty.featureid}" >FeatureName</label>
-      <div class="controls">   
-        <input type="text" name="featureid" id="featureid" 
-               style="width:350px;height:18px;color:#00ab8b;background-color:white" readonly="readonly"/>  
+      <div class="controls">
+        <input type="text" name="featureid" id="featureid"
+               style="width:350px;height:18px;color:#00ab8b;background-color:white" readonly="readonly"/>
       </div>
     </div>
-    
+
     <!-- Name -->
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px"> 
-      <label class="control-label" for="name" style="color:#687684;font-style:normal;font-weight:normal;" 
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
+      <label class="control-label" for="name" style="color:#687684;font-style:normal;font-weight:normal;"
         th:text="#{modal.editproperty.propertyname}" >Property Name</label>
-      <div class="controls">   
-        <input type="text" name="name" id="name" 
-        style="width:350px;height:18px;color:#008bab;background-color:white" readonly="readonly" />  
+      <div class="controls">
+        <input type="text" name="name" id="name"
+        style="width:350px;height:18px;color:#008bab;background-color:white" readonly="readonly" />
       </div>
     </div>
-    
-    <!-- Description --> 
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">   
+
+    <!-- Description -->
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
       <label class="control-label" for="pDesc" style="color:#687684;font-style:normal"
-             th:text="#{modal.editproperty.description}">Description</label>  
+             th:text="#{modal.editproperty.description}">Description</label>
       <div class="controls">
         <textarea class="field span4" style="width:350px;color:#008bab"
             name="desc" id="pDesc" rows="2" cols="30"></textarea>
       </div>
     </div>
-    
-    <!-- Type --> 
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">  
-      <label class="control-label" for="pType" style="color:#687684;font-style:normal" 
+
+    <!-- Type -->
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
+      <label class="control-label" for="pType" style="color:#687684;font-style:normal"
              th:text="#{modal.editproperty.type}" >Type</label>
       <div class="controls" >
         <div class="btn-group">
             <input type="text" name="pType" id="pType" style="width:350px;height:18px;color:#008bab;background-color:white"/>
-            <button type="button" class="btn btn-green dropdown-toggle" data-toggle="dropdown" 
+            <button type="button" class="btn btn-green dropdown-toggle" data-toggle="dropdown"
                     style="float:right;margin-left:-5px">
               <span class="caret"></span>
               <span class="sr-only"><i class="icon-cog icon-white" ></i></span>
@@ -249,23 +249,23 @@
        </div>
     </div>
 
-    <!-- Value --> 
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px"> 
-      <label class="control-label" for="pValue" 
-             style="color:#687684;font-style:normal;font-weight:normal;" 
+    <!-- Value -->
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
+      <label class="control-label" for="pValue"
+             style="color:#687684;font-style:normal;font-weight:normal;"
              th:text="#{modal.editproperty.value}" >Value</label>
-      <div class="controls" id="div-value-property">   
-        <input type="text" name="pValue" id="pValue" 
-               style="width:350px;height:18px;color:#008bab;background-color:white" 
-               required="required" />  
+      <div class="controls" id="div-value-property">
+        <input type="text" name="pValue" id="pValue"
+               style="width:350px;height:18px;color:#008bab;background-color:white"
+               required="required" />
       </div>
     </div>
-       
-    <!-- FixedValues --> 
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px" id="updatePropertyFixedValueControlGroup">  
-      <label class="control-label" for="pValue" 
-             style="color:#687684;font-style:normal;font-weight:normal;" 
-             th:text="#{modal.editproperty.fixedValues}">FixedValue</label>  
+
+    <!-- FixedValues -->
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px" id="updatePropertyFixedValueControlGroup">
+      <label class="control-label" for="pValue"
+             style="color:#687684;font-style:normal;font-weight:normal;"
+             th:text="#{modal.editproperty.fixedValues}">FixedValue</label>
       <div class="controls">
       <table class="table table-bordered table-condensed">
         <tbody id="modalEditPropertyFixedValues">
@@ -273,7 +273,7 @@
         </table>
       </div>
     </div>
-    
+
    </div>
 
    <div class="modal-footer" >
@@ -287,19 +287,19 @@
   </div>
 
   </div>
-  
+
 </form>
 
  <script type="text/javascript" >
- 
+
     $(document).on("click", ".open-EditPropertyDialog", function () {
         ff4j_updateModalEditProperty($(this).data('id'));
     });
-    
+
     $(document).on("click", ".open-DeletePropertyDialog", function () {
     	ff4j_updateModalDeleteProperty($(this).data('id'));
     });
-    
+
     $(document).on("click", ".open-EditFeaturePropertyDialog", function () {
     	var featureId    = $(this).data('featureid');
     	var propertyName = $(this).data('propertyname');
@@ -317,22 +317,22 @@
            modalEditProperty.find("#pValue").val(myProperty.value);
         });
     });
-    
-    $(document).on("click", ".open-createPropertyDialog", function () { 
+
+    $(document).on("click", ".open-createPropertyDialog", function () {
         $(".modal-body #name").val('');
         $(".modal-body #pDesc").val('');
         $(".modal-body #pType").val('');
         $(".modal-body #pValue").val('');
         var featId = $(this).data('featureid');
-        if(!featId){   
+        if(!featId){
              // Hide the FeatureName control
              $("#createPropertyFeatureControlGroup").hide();
          } else {
              $("#createPropertyFeatureControlGroup").show();
              $(".modal-body #featureid").val(featId);
-         }     
+         }
      });
-    
+
     $(document).ready(function() {
         $('#updatePropertyForm').on('submit', function(e) {
             // do something
@@ -342,7 +342,7 @@
             } else {
                 e.preventDefault();
                 var $this = $(this);
-                 
+
                 // invoke controller only
                 $.ajax({
                   url: $this.attr('action'),
@@ -351,24 +351,24 @@
                   async: false,
                   success: function(html) {}
                 });
-                
+
                 // Update modal hide modal top
                 $('#modalEditProperty').modal("hide");
                 ff4j_drawCustomProperties(featId);
             }
         });
     });
-     
+
      $(document).ready(function() {
         $('#createPropertyForm').on('submit', function(e) {
         var featId = $(".modal-body #featureid").val();
         if(featId == "" || featId == null) {
             e.submit();
-            
+
         } else {
             e.preventDefault();
             var $this = $(this);
-             
+
             // invoke controller only
             $.ajax({
               url: $this.attr('action'),
@@ -377,29 +377,29 @@
               async: false,
               success: function(html) {}
              });
-            
+
              $("#modalCreateProperty").modal("hide");
              ff4j_drawCustomProperties(featId);
-        }   
+        }
        });
      });
-    
+
  </script>
 
-</div>
+</th:block>
 
 <!-- ********************* -->
 <!-- MODAL RENAME PROPERTY -->
 <!-- ********************* -->
-<div th:fragment="modal-rename">
+<th:block th:fragment="modal-rename">
 
 <form class="form-horizontal" th:action="@{properties}" action="" method="POST" >
 
-  <div class="modal hide fade" id="modalRenameProperty" tabindex="-1" 
+  <div class="modal hide fade" id="modalRenameProperty" tabindex="-1"
        role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-    
-    <div class="modal-header">   
-      <button class="close" data-dismiss="modal">x</button>   
+
+    <div class="modal-header">
+      <button class="close" data-dismiss="modal">x</button>
       <h4 id="myModalLabel">
       <i class="icon-th-list icon-white"></i>&nbsp;
       <span th:text="#{modal.renameproperty.title}" >Rename Property</span>
@@ -407,11 +407,11 @@
     </div>
 
     <div class="modal-body" style="height:120px">
-    
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">   
+
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
       <label class="control-label" for="group" style="color:#687684;font-style:normal">
         <span th:text="#{modal.renameproperty.list}" >Property List</span>
-      </label> 
+      </label>
         <div class="controls">
           <div class="btn-group">
             <input type="text" name="name" id="name" style="width:350px;height:18px;color:#008bab" />
@@ -426,19 +426,19 @@
                 </a>
                </li>
             </ul>
-          </div> <!-- btn-group -->     
+          </div> <!-- btn-group -->
         </div> <!-- controls -->
-      </div> <!-- control-group -->      
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px"> 
-      <label class="control-label" for="uid" 
+      </div> <!-- control-group -->
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
+      <label class="control-label" for="uid"
         style="color:#687684;font-style:normal;font-weight:normal;" th:text="#{modal.renameproperty.new}" >New Name </label>
-      <div class="controls">   
-        <input type="text" name="newname" id="newname" 
-            style="width:350px;height:18px;color:#008bab;background-color:white" required="required" />  
+      <div class="controls">
+        <input type="text" name="newname" id="newname"
+            style="width:350px;height:18px;color:#008bab;background-color:white" required="required" />
       </div>
-    </div> 
     </div>
-    
+    </div>
+
      <div class="modal-footer" >
     <button class="btn btn" data-dismiss="modal">
       <i class="icon-remove" ></i>&nbsp;
@@ -448,27 +448,27 @@
       <i class="icon-ok icon-white" ></i>&nbsp;
       <span th:text="#{modal.button.validate}">Validate</span></button>
   </div>
-    
+
    <input type="hidden" name="op" value="renameProperty"  />
 
   </div>
 </form>
 
 
-</div>
+</th:block>
 
 <!-- ******************** -->
 <!-- MODAL COPY PROPERTY  -->
 <!-- ******************** -->
-<div th:fragment="modal-copy">
+<th:block th:fragment="modal-copy">
 
 <form class="form-horizontal" th:action="@{properties}" action="" method="POST" >
 
-  <div class="modal hide fade" id="modalCopyProperty" tabindex="-1" 
+  <div class="modal hide fade" id="modalCopyProperty" tabindex="-1"
        role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-    
-    <div class="modal-header">   
-      <button class="close" data-dismiss="modal">x</button>   
+
+    <div class="modal-header">
+      <button class="close" data-dismiss="modal">x</button>
       <h4 id="myModalLabel">
       <i class="icon-th-list icon-white"></i>&nbsp;
       <span th:text="#{modal.copyproperty.title}" >Copy Property</span>
@@ -476,11 +476,11 @@
     </div>
 
     <div class="modal-body" style="height:120px">
-    
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">   
+
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
       <label class="control-label" for="group" style="color:#687684;font-style:normal">
         <span th:text="#{modal.copyproperty.list}" >Property List</span>
-      </label> 
+      </label>
         <div class="controls">
           <div class="btn-group">
             <input type="text" name="name" id="name" style="width:350px;height:18px;color:#008bab" />
@@ -495,19 +495,19 @@
                 </a>
                </li>
             </ul>
-          </div> <!-- btn-group -->     
+          </div> <!-- btn-group -->
         </div> <!-- controls -->
-      </div> <!-- control-group -->      
-    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px"> 
-      <label class="control-label" for="uid" 
+      </div> <!-- control-group -->
+    <div class="control-group" style="margin-left:0px;float:left;margin-left:-45px">
+      <label class="control-label" for="uid"
         style="color:#687684;font-style:normal;font-weight:normal;" th:text="#{modal.copyproperty.new}" >New Name </label>
-      <div class="controls">   
-        <input type="text" name="newname" id="newname" 
-            style="width:350px;height:18px;color:#008bab;background-color:white" required="required" />  
+      <div class="controls">
+        <input type="text" name="newname" id="newname"
+            style="width:350px;height:18px;color:#008bab;background-color:white" required="required" />
       </div>
-    </div> 
     </div>
-    
+    </div>
+
      <div class="modal-footer" >
     <button class="btn btn" data-dismiss="modal">
       <i class="icon-remove" ></i>&nbsp;
@@ -517,14 +517,14 @@
       <i class="icon-ok icon-white" ></i>&nbsp;
       <span th:text="#{modal.button.validate}">Validate</span></button>
   </div>
-    
+
    <input type="hidden" name="op" value="copyProperty"  />
 
   </div>
 </form>
 
 
-</div>
+</th:block>
 
 
 

--- a/ff4j-web/src/main/resources/views/view-navbar.html
+++ b/ff4j-web/src/main/resources/views/view-navbar.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
 <body>
 
-<div th:fragment="navbar">
+<th:block th:fragment="navbar">
  <div class="navbar-inner">
   <div class="container">
 
@@ -10,31 +10,31 @@
     <img src="" th:src="@{static/img/ff4j.png}" height="45px" width="70px" style="height:45px;margin-top:10px"/>
     &nbsp;<span th:text="#{navbar.title}" >Administration Console</span>
    </a>
-        
+
    <div class="nav-collapse"  style="margin-top:15px">
    	<ul class="nav pull-right">
    	 <li>
    	  <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top" style="margin-top:10px">
 	   <input type="hidden" name="cmd" value="_s-xclick" />
 	   <input type="hidden" name="hosted_button_id" value="XD2BQ9KDJ7SGU" />
-	   <input type="image" 
+	   <input type="image"
 		  th:src="@{static/img/btn_donate_LG.gif}"
 		  src="https://www.paypalobjects.com/en_GB/i/btn/btn_donate_LG.gif"
 		  border="0" name="submit" alt="Donate to FF4J" />
-		 <img alt="" border="0" 
-						src="https://www.paypalobjects.com/fr_FR/i/scr/pixel.gif" width="1" height="1" 
+		 <img alt="" border="0"
+						src="https://www.paypalobjects.com/fr_FR/i/scr/pixel.gif" width="1" height="1"
 						th:src="@{static/img/pixel.gif}"/>
 				 </form>
 		</p>
-     </li>	 
-	 
+     </li>
+
 	 <li class="dropdown"><a href="#">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Lang:</span></a></li>
-     
+
 	 <li class="dropdown">
-	  
+
 	  <a href="#" class="dropdown-toggle" data-toggle="dropdown">
 	   <span th:if="${#locale.language == 'en'}">
-	    <img src="" th:src="@{static/img/flags/flagEnglish.png}" style="height:25px" /> 
+	    <img src="" th:src="@{static/img/flags/flagEnglish.png}" style="height:25px" />
 	   </span>
        <span th:if="${#locale.language == 'es'}">
 	    <img src="" th:src="@{static/img/flags/flagSpain.png}" style="height:25px" />
@@ -46,10 +46,10 @@
 	    <img src="" th:src="@{static/img/flags/flagBrasil.png}" style="height:25px" />
 	   </span>
 	   <span th:if="${#locale.language == 'fr'}">
-	    <img src="" th:src="@{static/img/flags/flagFrance.png}" style="height:25px" /> 
+	    <img src="" th:src="@{static/img/flags/flagFrance.png}" style="height:25px" />
 	   </span>
 	   <span th:if="${#locale.language == 'de'}">
-	    <img src="" th:src="@{static/img/flags/flagGermany.png}" style="height:25px" /> 
+	    <img src="" th:src="@{static/img/flags/flagGermany.png}" style="height:25px" />
 	   </span>
        <span th:if="${#locale.language == 'ja'}">
 	    <img src="" th:src="@{static/img/flags/flagJapanese.png}" style="height:25px" />
@@ -62,7 +62,7 @@
 	   </span>
 	   <b class="caret"></b>
       </a>
-      
+
       <ul class="dropdown-menu">
       	<li><a href="?lang=en"><img src="" th:src="@{static/img/flags/flagEnglish.png}" style="height:15px" />&nbsp;English</a></li>
         <li><a href="?lang=es"><img src="" th:src="@{static/img/flags/flagSpain.png}" style="height:15px" />&nbsp;Español</a></li>
@@ -74,20 +74,20 @@
         <li><a href="?lang=cn"><img src="" th:src="@{static/img/flags/flagChina.png}" style="height:15px" />&nbsp;中文</a></li>
         <li><a href="?lang=ar"><img src="" th:src="@{static/img/flags/flagEmirate.png}" style="height:15px" />&nbsp;العربية‎</a></li>
       </ul>
-      
+
 	</li>
-     
+
 	</ul>
    </div>
   </div>
  </div>
-</div>
+</th:block>
 
-<div th:fragment="subnavbar">
+<th:block th:fragment="subnavbar">
  <div class="subnavbar-inner">
   <div class="container">
    <ul class="mainnav">
-    
+
     <li class="active2">
      <a href="" th:href="@{home}" >
       <i class="icon-home"></i>
@@ -102,46 +102,46 @@
     </li>
     <li>
      <a href="" th:href="@{properties}" >
-      <i class="icon-list-alt"></i> 
+      <i class="icon-list-alt"></i>
       <span th:text="#{navbar.main.properties}" >Properties</span>
      </a>
     </li>
         <li>
           <a href="" th:href="@{featureUsage}" >
-           <i class="icon-dashboard"></i> 
+           <i class="icon-dashboard"></i>
            <span th:text="#{navbar.main.supervision}" >FeatureUsage</span>
            </a>
-        </li>   
+        </li>
          <li>
           <a href="" th:href="@{settings}" >
-           <i class="icon-cog"></i> 
+           <i class="icon-cog"></i>
            <span th:text="#{navbar.main.settings}" >Settings</span>
            </a>
-        </li> 
+        </li>
          <li>
           <a href="" th:href="@{infos}" >
-           <i class="icon-info"></i> 
+           <i class="icon-info"></i>
            <span th:text="#{navbar.main.about}" >About</span>
            </a>
-        </li>   
+        </li>
       </ul>
-      
+
       <div style="float:right;margin-top:20px;color:#687684">
-       <span th:text="#{navbar.main.uptime}" >Uptime</span> 
+       <span th:text="#{navbar.main.uptime}" >Uptime</span>
        <i class="icon-time"></i>: <span th:text="${uptime}">n/a</span>
       </div>
     </div>
   </div>
-</div>
+</th:block>
 
-<div th:fragment="subnavbarfeatures">
+<th:block th:fragment="subnavbarfeatures">
  <div class="subnavbar-inner">
   <div class="container">
    <ul class="mainnav">
     <li>
      <a href="" th:href="@{home}" >
        <i class="icon-arrow-left"></i>
-       <span th:text="#{navbar.main.back}" >Back</span> 
+       <span th:text="#{navbar.main.back}" >Back</span>
      </a>
     </li>
      <li class="active2">
@@ -187,9 +187,9 @@
       </div>
     </div>
   </div>
-</div>
+</th:block>
 
-<div th:fragment="subnavbarproperties">
+<th:block th:fragment="subnavbarproperties">
  <div class="subnavbar-inner">
   <div class="container">
    <ul class="mainnav">
@@ -201,7 +201,7 @@
     </li>
     <li class="active2">
      <a href="" th:href="@{properties}" >
-      <i class="icon-list-alt"></i> 
+      <i class="icon-list-alt"></i>
       <span th:text="#{navbar.main.properties}" >Properties</span>
      </a>
     </li>
@@ -236,25 +236,25 @@
       </div>
     </div>
   </div>
-</div>
+</th:block>
 
-<div th:fragment="subnavbarsupervision">
+<th:block th:fragment="subnavbarsupervision">
  <div class="subnavbar-inner">
   <div class="container">
    <ul class="mainnav">
     <li>
      <a href="" th:href="@{home}" >
        <i class="icon-arrow-left"></i>
-       <span th:text="#{navbar.main.back}" >Back</span> 
+       <span th:text="#{navbar.main.back}" >Back</span>
      </a>
     </li>
      <li class="active2">
       <a href="" th:href="@{featureUsage}" >
-      <i class="icon-dashboard"></i> 
+      <i class="icon-dashboard"></i>
       <span th:text="#{navbar.main.supervision}" >Dashboard</span>
       </a>
-    </li>  
-    
+    </li>
+
     <li>
      <a href="" th:href="@{timeSeries}" >
       <i class="icon-bar-chart"></i>
@@ -280,25 +280,25 @@
       </div>
     </div>
   </div>
-</div>
+</th:block>
 
-<div th:fragment="subnavbaraudit">
+<th:block th:fragment="subnavbaraudit">
  <div class="subnavbar-inner">
   <div class="container">
    <ul class="mainnav">
     <li>
      <a href="" th:href="@{home}" >
        <i class="icon-arrow-left"></i>
-       <span th:text="#{navbar.main.back}" >Back</span> 
+       <span th:text="#{navbar.main.back}" >Back</span>
      </a>
     </li>
      <li >
       <a href="" th:href="@{featureUsage}" >
-      <i class="icon-dashboard"></i> 
+      <i class="icon-dashboard"></i>
       <span th:text="#{navbar.main.supervision}" >Dashboard</span>
       </a>
-    </li>  
-    
+    </li>
+
     <li>
      <a href="" th:href="@{timeSeries}" >
       <i class="icon-bar-chart"></i>
@@ -324,25 +324,25 @@
       </div>
     </div>
   </div>
-</div>
+</th:block>
 
-<div th:fragment="subnavbartimeseries">
+<th:block th:fragment="subnavbartimeseries">
  <div class="subnavbar-inner">
   <div class="container">
    <ul class="mainnav">
     <li>
      <a href="" th:href="@{home}" >
        <i class="icon-arrow-left"></i>
-       <span th:text="#{navbar.main.back}" >Back</span> 
+       <span th:text="#{navbar.main.back}" >Back</span>
      </a>
     </li>
      <li >
       <a href="" th:href="@{featureUsage}" >
-      <i class="icon-dashboard"></i> 
+      <i class="icon-dashboard"></i>
       <span th:text="#{navbar.main.supervision}" >Dashboard</span>
       </a>
-    </li>  
-    
+    </li>
+
     <li class="active2">
      <a href="" th:href="@{timeSeries}" >
       <i class="icon-bar-chart"></i>
@@ -368,13 +368,13 @@
       </div>
     </div>
   </div>
-</div>
+</th:block>
 
-<div th:fragment="subnavbarback">
+<th:block th:fragment="subnavbarback">
  <div class="subnavbar-inner">
   <div class="container">
    <ul class="mainnav">
-    
+
     <li style="border-right:1px solid #CCCCCC">
      <a href="" th:href="@{home}" >
       <i class="icon-arrow-left"></i>
@@ -387,12 +387,12 @@
       <span th:text="#{navbar.main.about}" >About</span>
      </a>
     </li>
-   
+
     </ul>
-    
+
     </div>
   </div>
-</div>
-    
+</th:block>
+
 </body>
 </html>

--- a/ff4j-web/src/main/resources/views/view-properties.html
+++ b/ff4j-web/src/main/resources/views/view-properties.html
@@ -1,25 +1,25 @@
 <!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:include="header :: head"></head>
+<head th:insert="~{header :: head}"></head>
 <!-- DataTables -->
 <script type="text/javascript" src="" th:src="@{static/js/jquery.dataTables.min.js}"></script>
 <link rel="stylesheet" type="text/css" media="all" href="" th:href="@{static/css/jquery.dataTables.min.css}" />
 
 <body>
-  
-<div class="navbar navbar-fixed-top" th:include="navbar :: navbar"></div>
 
-<div class="subnavbar" th:include="navbar :: subnavbarproperties"></div>
+<div class="navbar navbar-fixed-top" th:insert="~{navbar :: navbar}"></div>
+
+<div class="subnavbar" th:insert="~{navbar :: subnavbarproperties}"></div>
 
 <div id="wrapper" class="container" >
  <div class="row">
-  <div class="span9"> 
+  <div class="span9">
    <div id="content" class="clearfix" >
     <div class="main-inner" style="margin-top:60px">
      <div class="container">
 
- <div th:include="messages :: messagebar"></div>
-     
+ <div th:insert="~{messages :: messagebar}"></div>
+
  <div class="span12">
   <div class="widget widget-nopad">
    <div class="widget-header">
@@ -27,13 +27,13 @@
      <h3><span th:text="#{property.title}" >Properties</span></h3>
    </div>
    <div class="widget-content" style="padding:10px">
-   
+
     <script type="text/javascript">
     $(document).ready(function(){
         $('#propertyTable').DataTable();
     });
  </script>
- 
+
     <table id="propertyTable" name="propertyTable"  class="table table-striped table-bordered" style="margin-top:10px;">
      <thead>
       <tr>
@@ -49,7 +49,7 @@
     <tr th:each="curProp,indexPop : ${listOfProperties}">
       <td>
         <!-- PropertyName -->
-        <a class="ff4j-tooltip" tooltip="" 
+        <a class="ff4j-tooltip" tooltip=""
            th:attr="tooltip=${curProp.description}" style="color:#008bab;font-weight:bold">
         <span th:text="${curProp.name}">uid</span></a>
       </td>
@@ -63,30 +63,30 @@
        <span style="color:#008bab" th:text="${curProp. fixedValues}">---</span>
       </td>
        <td style="width:5%;text-align:center" th:if="${enableEdit}">
-      <a data-toggle="modal" href="#modalEditProperty" 
+      <a data-toggle="modal" href="#modalEditProperty"
          th:attr="data-id=${curProp.name}"
          style="width:6px;margin-left:-3px;color:white;background-color:#008bab"
          class="open-EditPropertyDialog btn">
        <i class="icon-pencil"></i>
       </a>
      </td>
-     
+
      <td style="width:5%;text-align:center" th:if="${enableEdit}">
-         <a data-toggle="modal" href="#modalDeleteProperty" 
+         <a data-toggle="modal" href="#modalDeleteProperty"
          th:attr="data-id=${curProp.name}"
          style="width:6px;margin-left:-3px;color:white;background-color:#ab0000"
          class="open-DeletePropertyDialog btn">
          <i class="icon-trash"></i>
         </a>
      </td>
-     
+
     </tr>
     </tbody>
     </table>
     </div>
    </div>
   </div>
-    	
+
 	 </div>
 	</div>
    </div>
@@ -94,15 +94,15 @@
  </div>
 </div>
 
-<div th:include="modal-properties :: modal-createProperty"></div>
+<div th:insert="~{modal-properties :: modal-createProperty}"></div>
 
-<div th:include="modal-properties :: modal-updateProperty"></div>
+<div th:insert="~{modal-properties :: modal-updateProperty}"></div>
 
-<div th:include="modal-properties :: modal-deleteProperty"></div>
+<div th:insert="~{modal-properties :: modal-deleteProperty}"></div>
 
-<div th:include="modal-properties :: modal-rename"></div>
+<div th:insert="~{modal-properties :: modal-rename}"></div>
 
-<div th:include="modal-properties :: modal-copy"></div>  
- 
+<div th:insert="~{modal-properties :: modal-copy}"></div>
+
 </body>
 </html>

--- a/ff4j-web/src/main/resources/views/view-settings.html
+++ b/ff4j-web/src/main/resources/views/view-settings.html
@@ -1,30 +1,30 @@
 <!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:include="header :: head"></head>
+<head th:insert="~{header :: head}"></head>
 <body>
-  
-<div class="navbar navbar-fixed-top" th:include="navbar :: navbar"></div>
 
-<div class="subnavbar" th:include="navbar :: subnavbar"></div>
+<div class="navbar navbar-fixed-top" th:insert="~{navbar :: navbar}"></div>
+
+<div class="subnavbar" th:insert="~{navbar :: subnavbar}"></div>
 
 <div id="wrapper" class="container" >
  <div class="row">
-  <div class="span9"> 
+  <div class="span9">
    <div id="content" class="clearfix" >
     <div class="main-inner" style="margin-top:60px">
      <div class="container">
-          
+
             <div class="widget widget-nopad">
-            <div class="widget-header"> 
+            <div class="widget-header">
               <i class="icon-cogs"></i>
               <h3><span th:text="#{setting.title}" >Settings</span></h3>
             </div>
              <div class="widget-content">
-                 
+
                  <h6 class="bigstats">
-          
+
     <table style="border-collapse:separate;border-spacing:0 10px;text-transform:none">
-     
+
      <tr>
       <td style="width:300px;text-align:right;margin-right:18px">
        <h4 th:text="#{setting.audit}" >Audit</h4>
@@ -43,20 +43,20 @@
       </td>
      </tr>
     </table>
-    
-    </h6>              
+
+    </h6>
                 </div>
-                <!-- /widget-content --> 
+                <!-- /widget-content -->
 
           </div>
-    	
-    	
+
+
 	 </div>
 	</div>
    </div>
   </div>
  </div>
 </div>
-   
+
 </body>
 </html>

--- a/ff4j-web/src/main/resources/views/view-timeSeries.html
+++ b/ff4j-web/src/main/resources/views/view-timeSeries.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:include="header :: head"></head>
+<head th:insert="~{header :: head}"></head>
 
 <script type="text/javascript" src="" th:src="@{static/js/jqplot/jquery.jqplot.min.js}"></script>
 <script type="text/javascript" src="" th:src="@{static/js/jqplot/plugins/jqplot.barRenderer.min.js}"></script>
@@ -20,20 +20,20 @@
 <link rel="stylesheet" type="text/css" media="all" href="" th:href="@{static/css/bootstrap-datetimepicker.min.css}" />
 <link rel="stylesheet" type="text/css" media="all" href="" th:href="@{static/js/jqplot/jquery.jqplot.min.css}" />
 <body>
-  
-<div class="navbar navbar-fixed-top" th:include="navbar :: navbar"></div>
 
-<div class="subnavbar" th:include="navbar :: subnavbartimeseries"></div>
+<div class="navbar navbar-fixed-top" th:insert="~{navbar :: navbar}"></div>
+
+<div class="subnavbar" th:insert="~{navbar :: subnavbartimeseries}"></div>
 
 <div id="wrapper" class="container" >
  <div class="row">
-  <div class="span9"> 
+  <div class="span9">
    <div id="content" class="clearfix" >
     <div class="main-inner" style="margin-top:60px">
      <div class="container">
- 
+
       <div class="row">
-       <div class="span12">     
+       <div class="span12">
         <div class="widget">
          <div class="widget-header">
          <i class="icon-bar-chart"></i>
@@ -74,36 +74,36 @@
       </div> <!-- row -->
 
       <div class="row">
-       <div class="span12">     
+       <div class="span12">
         <div class="widget">
          <div class="widget-header">
           <i class="icon-bar-chart"></i>
           <h3 th:text="#{navbar.main.timeseries}">TimeSeries</h3>
          </div>
          <div class="widget-content">
-          
+
           <p>Click on serie name in Legend to toggle on/off series.</p>
-          
+
           <div id="maincurve" class="maincurveStyle"></div>
            <script th:inline="javascript">
             var startTime = /*[[${fromJS}]]*/ null;
             var endTime   = /*[[${toJS}]]*/ null;
             console.log(startTime);
             $(document).ready(
-            		ff4j_renderSparkline('maincurve', 
+            		ff4j_renderSparkline('maincurve',
             				ff4j_computeSparkline('api/timeSeries', startTime, endTime)));
            </script>
          </div>
         </div>
        </div>
       </div>
-      
+
           </div>
         </div>
       </div>
     </div>
   </div>
 </div>
-   
+
 </body>
 </html>


### PR DESCRIPTION
Fixes deprecation warnings in ff4j-web, as mentioned in issue #701 

# Description

In Thymeleaf 3.1, th:include was deprecated and so is the unpacked fragment expression syntax.
https://www.thymeleaf.org/doc/articles/thymeleaf31whatsnew.html#deprecation-of-thinclude

th:insert behaves slightly differently, so some elements should be changed to th:block or explicitly use the th:remove="tag" attribute.
