### PR TITLE
issue 705 Replace SimpleDateFormat with DateTimeFormatter that is thread safe

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/strategy/time/ReleaseDateFlipStrategy.java
+++ b/ff4j-core/src/main/java/org/ff4j/strategy/time/ReleaseDateFlipStrategy.java
@@ -9,9 +9,9 @@ package org.ff4j.strategy.time;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,8 +20,7 @@ package org.ff4j.strategy.time;
  * #L%
  */
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Map;
 
@@ -29,23 +28,26 @@ import org.ff4j.core.FeatureStore;
 import org.ff4j.core.FlippingExecutionContext;
 import org.ff4j.strategy.AbstractFlipStrategy;
 
+import static org.ff4j.utils.TimeUtils.dateToString;
+import static org.ff4j.utils.TimeUtils.stringToDate;
+
 /**
  * The feature will be flipped after release date is reached.
- * 
+ *
  * @author Cedrick Lunven (@clunven)
  */
 public class ReleaseDateFlipStrategy extends AbstractFlipStrategy {
-    
+
     /** Serial. */
     private static final long serialVersionUID = 3857531924888301636L;
 
     public static final String DATE_PATTERN = "yyyy-MM-dd-HH:mm";
-    
+
     /** Pattern to create a release Date. */
-    public static final SimpleDateFormat SDF = new SimpleDateFormat(DATE_PATTERN);
+    public static final DateTimeFormatter SDF = DateTimeFormatter.ofPattern(DATE_PATTERN);
 
     /** Constant for release Date. */
-    private static final String PARAMNAME_RELEASEDATE = "releaseDate";
+    public static final String PARAMNAME_RELEASEDATE = "releaseDate";
 
     /** Release Date. */
     private Date releaseDate = new Date();
@@ -57,13 +59,13 @@ public class ReleaseDateFlipStrategy extends AbstractFlipStrategy {
 
     /**
      * Initialization with a date expression.
-     * 
-     * @param date
+     *
+     * @param strDate
      */
     public ReleaseDateFlipStrategy(String strDate) {
         try {
-            this.releaseDate = SDF.parse(strDate);
-        } catch (ParseException e) {
+            this.releaseDate = stringToDate(strDate,SDF);
+        } catch (Throwable e) {
             throw new IllegalArgumentException("Cannot parse release date, invalid format correct is '" + DATE_PATTERN + "'", e);
         }
         getInitParams().put(PARAMNAME_RELEASEDATE, strDate);
@@ -71,12 +73,12 @@ public class ReleaseDateFlipStrategy extends AbstractFlipStrategy {
 
     /**
      * Initialisation with a date.
-     * 
+     *
      * @param releaseDate
      */
     public ReleaseDateFlipStrategy(Date releaseDate) {
         this.releaseDate = releaseDate;
-        getInitParams().put(PARAMNAME_RELEASEDATE, SDF.format(releaseDate));
+        getInitParams().put(PARAMNAME_RELEASEDATE, dateToString(releaseDate,SDF));
     }
 
     /** {@inheritDoc} */
@@ -85,8 +87,8 @@ public class ReleaseDateFlipStrategy extends AbstractFlipStrategy {
         super.init(featureName, initParam);
         assertRequiredParameter(PARAMNAME_RELEASEDATE);
         try {
-            this.releaseDate = SDF.parse(initParam.get(PARAMNAME_RELEASEDATE));
-        } catch (ParseException e) {
+            this.releaseDate = stringToDate(initParam.get(PARAMNAME_RELEASEDATE), SDF);
+        } catch (Throwable e) {
             throw new IllegalArgumentException("Cannot parse release date, invalid format correct is '" + DATE_PATTERN + "'", e);
         }
     }
@@ -99,10 +101,10 @@ public class ReleaseDateFlipStrategy extends AbstractFlipStrategy {
         // No use of executionContext
         return new Date().after(releaseDate);
     }
-    
+
     /**
      * Setter accessor for attribute 'releaseDate'.
-     * 
+     *
      * @param releaseDate
      *            new value for 'releaseDate '
      */

--- a/ff4j-core/src/main/java/org/ff4j/strategy/time/ReleaseDateFlipStrategy.java
+++ b/ff4j-core/src/main/java/org/ff4j/strategy/time/ReleaseDateFlipStrategy.java
@@ -44,7 +44,8 @@ public class ReleaseDateFlipStrategy extends AbstractFlipStrategy {
     public static final String DATE_PATTERN = "yyyy-MM-dd-HH:mm";
 
     /** Pattern to create a release Date. */
-    public static final DateTimeFormatter SDF = DateTimeFormatter.ofPattern(DATE_PATTERN);
+    public static final DateTimeFormatter SDF
+            = DateTimeFormatter.ofPattern(DATE_PATTERN);
 
     /** Constant for release Date. */
     public static final String PARAMNAME_RELEASEDATE = "releaseDate";
@@ -78,7 +79,8 @@ public class ReleaseDateFlipStrategy extends AbstractFlipStrategy {
      */
     public ReleaseDateFlipStrategy(Date releaseDate) {
         this.releaseDate = releaseDate;
-        getInitParams().put(PARAMNAME_RELEASEDATE, dateToString(releaseDate,SDF));
+        getInitParams().put(PARAMNAME_RELEASEDATE,
+                dateToString(releaseDate,SDF));
     }
 
     /** {@inheritDoc} */
@@ -87,7 +89,8 @@ public class ReleaseDateFlipStrategy extends AbstractFlipStrategy {
         super.init(featureName, initParam);
         assertRequiredParameter(PARAMNAME_RELEASEDATE);
         try {
-            this.releaseDate = stringToDate(initParam.get(PARAMNAME_RELEASEDATE), SDF);
+            this.releaseDate = stringToDate(
+                    initParam.get(PARAMNAME_RELEASEDATE), SDF);
         } catch (Throwable e) {
             throw new IllegalArgumentException("Cannot parse release date, invalid format correct is '" + DATE_PATTERN + "'", e);
         }

--- a/ff4j-core/src/main/java/org/ff4j/utils/TimeUtils.java
+++ b/ff4j-core/src/main/java/org/ff4j/utils/TimeUtils.java
@@ -77,10 +77,10 @@ public class TimeUtils {
 	 * @return converted date
 	 */
 	public static Date stringToDate(String dateStr,
-								DateTimeFormatter dateTimeFormatter) {
+                    DateTimeFormatter dateTimeFormatter) {
 		return Date.from(LocalDateTime
-						.parse(dateStr, dateTimeFormatter)
-						.atZone(ZoneId.systemDefault()).toInstant());
+                      .parse(dateStr, dateTimeFormatter)
+                      .atZone(ZoneId.systemDefault()).toInstant());
 	}
 
 	/**
@@ -92,6 +92,6 @@ public class TimeUtils {
 	public static String dateToString(Date date,
 									  DateTimeFormatter dateTimeFormatter) {
 		return LocalDateTime.ofInstant(date.toInstant(),
-								ZoneOffset.UTC).format(dateTimeFormatter);
+                    ZoneOffset.UTC).format(dateTimeFormatter);
 	}
 }

--- a/ff4j-core/src/main/java/org/ff4j/utils/TimeUtils.java
+++ b/ff4j-core/src/main/java/org/ff4j/utils/TimeUtils.java
@@ -90,7 +90,7 @@ public class TimeUtils {
 	 * @return converted string
 	 */
 	public static String dateToString(Date date,
-									  DateTimeFormatter dateTimeFormatter) {
+                         DateTimeFormatter dateTimeFormatter) {
 		return LocalDateTime.ofInstant(date.toInstant(),
                     ZoneOffset.UTC).format(dateTimeFormatter);
 	}

--- a/ff4j-core/src/main/java/org/ff4j/utils/TimeUtils.java
+++ b/ff4j-core/src/main/java/org/ff4j/utils/TimeUtils.java
@@ -77,8 +77,9 @@ public class TimeUtils {
 	 * @return converted date
 	 */
 	public static Date stringToDate(String dateStr,
-									DateTimeFormatter dateTimeFormatter) {
-		return Date.from(LocalDateTime.parse(dateStr,dateTimeFormatter)
+								DateTimeFormatter dateTimeFormatter) {
+		return Date.from(LocalDateTime
+						.parse(dateStr, dateTimeFormatter)
 						.atZone(ZoneId.systemDefault()).toInstant());
 	}
 

--- a/ff4j-core/src/main/java/org/ff4j/utils/TimeUtils.java
+++ b/ff4j-core/src/main/java/org/ff4j/utils/TimeUtils.java
@@ -21,6 +21,10 @@ package org.ff4j.utils;
  */
 
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -66,4 +70,23 @@ public class TimeUtils {
 		return c2.getTimeInMillis();
 	}
 
+	/**
+	 * Converts string to date using DateTimFormatter
+	 * @param dateStr
+	 * @param dateTimeFormatter
+	 * @return converted date
+	 */
+	public static Date stringToDate(String dateStr, DateTimeFormatter dateTimeFormatter) {
+		return Date.from(LocalDateTime.parse(dateStr,dateTimeFormatter).atZone(ZoneId.systemDefault()).toInstant());
+	}
+
+	/**
+	 * Converts date to string using DateTimFormatter
+	 * @param date
+	 * @param dateTimeFormatter
+	 * @return converted string
+	 */
+	public static String dateToString(Date date, DateTimeFormatter dateTimeFormatter) {
+		return LocalDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC).format(dateTimeFormatter);
+	}
 }

--- a/ff4j-core/src/main/java/org/ff4j/utils/TimeUtils.java
+++ b/ff4j-core/src/main/java/org/ff4j/utils/TimeUtils.java
@@ -76,8 +76,10 @@ public class TimeUtils {
 	 * @param dateTimeFormatter
 	 * @return converted date
 	 */
-	public static Date stringToDate(String dateStr, DateTimeFormatter dateTimeFormatter) {
-		return Date.from(LocalDateTime.parse(dateStr,dateTimeFormatter).atZone(ZoneId.systemDefault()).toInstant());
+	public static Date stringToDate(String dateStr,
+									DateTimeFormatter dateTimeFormatter) {
+		return Date.from(LocalDateTime.parse(dateStr,dateTimeFormatter)
+						.atZone(ZoneId.systemDefault()).toInstant());
 	}
 
 	/**
@@ -86,7 +88,9 @@ public class TimeUtils {
 	 * @param dateTimeFormatter
 	 * @return converted string
 	 */
-	public static String dateToString(Date date, DateTimeFormatter dateTimeFormatter) {
-		return LocalDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC).format(dateTimeFormatter);
+	public static String dateToString(Date date,
+									  DateTimeFormatter dateTimeFormatter) {
+		return LocalDateTime.ofInstant(date.toInstant(),
+								ZoneOffset.UTC).format(dateTimeFormatter);
 	}
 }

--- a/ff4j-core/src/test/java/org/ff4j/test/strategy/ReleaseDateFlipStrategyMultiThreadTest.java
+++ b/ff4j-core/src/test/java/org/ff4j/test/strategy/ReleaseDateFlipStrategyMultiThreadTest.java
@@ -26,17 +26,11 @@ import org.ff4j.strategy.time.ReleaseDateFlipStrategy;
 import org.junit.Test;
 
 import java.text.ParseException;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
-import static org.ff4j.strategy.time.ReleaseDateFlipStrategy.PARAMNAME_RELEASEDATE;
-
-
 import static org.junit.Assert.assertEquals;
-import static org.junit.runners.model.MultipleFailureException.assertEmpty;
 
 
 /**
@@ -55,7 +49,9 @@ public class ReleaseDateFlipStrategyMultiThreadTest {
             "2023-01-01-10:26",
             "2023-01-01-10:27"
     };
+
     int numThreads = 40;
+
     private static CountDownLatch latch;
 
     private List<FeatureDateRunnable> runnables = new ArrayList<>();
@@ -63,22 +59,25 @@ public class ReleaseDateFlipStrategyMultiThreadTest {
 
 
     @Test
-    public void testMultipleThreads() throws ParseException, InterruptedException {
+    public void testMultipleThreads() throws InterruptedException {
         for(int i=0; i<numThreads; i++) {
-            runnables.add(new FeatureDateRunnable(validDates[i%validDates.length]));
+            runnables.add(new
+                    FeatureDateRunnable(validDates[i%validDates.length]));
         }
         latch = new CountDownLatch(numThreads);
         for(Runnable r : runnables) {
             new Thread(r).start();
         }
         latch.await();
-        logger.info("Ran "+ numThreads + " trials, got errors in " + errors.size() + " trials");
+        logger.info("Ran "+ numThreads + " trials, got errors in "
+                                        + errors.size() + " trials");
         assertEquals(new ArrayList<>(), errors);
     }
 
 
     static class FeatureDateRunnable implements Runnable {
         protected final Log logger = LogFactory.getLog(getClass());
+
         private String strDate;
 
         public FeatureDateRunnable(String strDate) {
@@ -86,9 +85,10 @@ public class ReleaseDateFlipStrategyMultiThreadTest {
         }
         public void run() {
             try {
-                ReleaseDateFlipStrategy strategy = new ReleaseDateFlipStrategy(strDate);
+                new ReleaseDateFlipStrategy(strDate);
             } catch(Throwable t) {
-                String message = "Exception thrown when creating ReleaseDateFlipStrategy with date: " + strDate;
+                String message = "Exception thrown when creating " +
+                        "ReleaseDateFlipStrategy with date: " + strDate;
                 errors.add(message);
                 logger.error(message, t);
             } finally {
@@ -96,6 +96,4 @@ public class ReleaseDateFlipStrategyMultiThreadTest {
             }
         }
     }
-
-
 }

--- a/ff4j-core/src/test/java/org/ff4j/test/strategy/ReleaseDateFlipStrategyMultiThreadTest.java
+++ b/ff4j-core/src/test/java/org/ff4j/test/strategy/ReleaseDateFlipStrategyMultiThreadTest.java
@@ -1,0 +1,101 @@
+package org.ff4j.test.strategy;
+
+/*-
+ * #%L
+ * ff4j-core
+ * %%
+ * Copyright (C) 2013 - 2023 FF4J
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.ff4j.strategy.time.ReleaseDateFlipStrategy;
+import org.junit.Test;
+
+import java.text.ParseException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static org.ff4j.strategy.time.ReleaseDateFlipStrategy.PARAMNAME_RELEASEDATE;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.runners.model.MultipleFailureException.assertEmpty;
+
+
+/**
+ * Testing class for {@link ReleaseDateFlipStrategy} class.
+ *
+ * @author Henry Naftulin
+ */
+public class ReleaseDateFlipStrategyMultiThreadTest {
+    protected final Log logger = LogFactory.getLog(getClass());
+
+    public static String[] validDates = {
+            "2023-01-01-10:22",
+            "2023-01-01-10:23",
+            "2023-01-01-10:24",
+            "2023-01-01-10:25",
+            "2023-01-01-10:26",
+            "2023-01-01-10:27"
+    };
+    int numThreads = 40;
+    private static CountDownLatch latch;
+
+    private List<FeatureDateRunnable> runnables = new ArrayList<>();
+    private static List<String> errors = new ArrayList<>();
+
+
+    @Test
+    public void testMultipleThreads() throws ParseException, InterruptedException {
+        for(int i=0; i<numThreads; i++) {
+            runnables.add(new FeatureDateRunnable(validDates[i%validDates.length]));
+        }
+        latch = new CountDownLatch(numThreads);
+        for(Runnable r : runnables) {
+            new Thread(r).start();
+        }
+        latch.await();
+        logger.info("Ran "+ numThreads + " trials, got errors in " + errors.size() + " trials");
+        assertEquals(new ArrayList<>(), errors);
+    }
+
+
+    static class FeatureDateRunnable implements Runnable {
+        protected final Log logger = LogFactory.getLog(getClass());
+        private String strDate;
+
+        public FeatureDateRunnable(String strDate) {
+            this.strDate = strDate;
+        }
+        public void run() {
+            try {
+                ReleaseDateFlipStrategy strategy = new ReleaseDateFlipStrategy(strDate);
+            } catch(Throwable t) {
+                String message = "Exception thrown when creating ReleaseDateFlipStrategy with date: " + strDate;
+                errors.add(message);
+                logger.error(message, t);
+            } finally {
+                latch.countDown();
+            }
+        }
+    }
+
+
+}

--- a/ff4j-core/src/test/java/org/ff4j/test/strategy/ReleaseDateFlipStrategyMultiThreadTest.java
+++ b/ff4j-core/src/test/java/org/ff4j/test/strategy/ReleaseDateFlipStrategyMultiThreadTest.java
@@ -25,7 +25,6 @@ import org.apache.commons.logging.LogFactory;
 import org.ff4j.strategy.time.ReleaseDateFlipStrategy;
 import org.junit.Test;
 
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -55,6 +54,7 @@ public class ReleaseDateFlipStrategyMultiThreadTest {
     private static CountDownLatch latch;
 
     private List<FeatureDateRunnable> runnables = new ArrayList<>();
+
     private static List<String> errors = new ArrayList<>();
 
 
@@ -83,6 +83,7 @@ public class ReleaseDateFlipStrategyMultiThreadTest {
         public FeatureDateRunnable(String strDate) {
             this.strDate = strDate;
         }
+
         public void run() {
             try {
                 new ReleaseDateFlipStrategy(strDate);


### PR DESCRIPTION

# Description
Replace SimpleDateFormat with DateTimeFormatter that is thread safe - fixes issue https://github.com/ff4j/ff4j/issues/705 which we see when we run multiple threads try to access all features that are backed up by DB. The unit test added exposes the issue in the original code as well

Closes : [Issue 705](https://github.com/ff4j/ff4j/issues/705)

Code contribution

# Checklist for self review:

- [x] My code follows the [contribution guidelines](https://github.com/ff4j/ff4j/blob/main/CONTRIBUTING.md) of this project
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My commits follow [conventional commit message guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
