### PR TITLE
BUG-710 - transactional create,update,delete, like in JdbcFeatureStore

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
@@ -230,7 +230,8 @@ public class JdbcPropertyStore extends AbstractPropertyStore {
             throw ex;
         }catch (Exception ex) {
             rollback(conn);
-            throw new PropertyAccessException("Cannot delete property database, SQL ERROR", ex);
+            throw new PropertyAccessException(
+                    "Cannot delete property database, SQL ERROR", ex);
         } finally {
             closeConnection(conn, previousAutoCommit);
         }

--- a/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
@@ -20,7 +20,14 @@ package org.ff4j.property.store;
  * #L%
  */
 import static org.ff4j.store.JdbcStoreConstants.COL_PROPERTY_ID;
-import static org.ff4j.utils.JdbcUtils.*;
+import static org.ff4j.utils.JdbcUtils.buildStatement;
+import static org.ff4j.utils.JdbcUtils.closeConnection;
+import static org.ff4j.utils.JdbcUtils.closeResultSet;
+import static org.ff4j.utils.JdbcUtils.closeStatement;
+import static org.ff4j.utils.JdbcUtils.executeUpdate;
+import static org.ff4j.utils.JdbcUtils.isTableExist;
+import static org.ff4j.utils.JdbcUtils.rollback;
+
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;

--- a/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
@@ -128,7 +128,8 @@ public class JdbcPropertyStore extends AbstractPropertyStore {
             throw ex;
         } catch (Exception ex) {
             rollback(conn);
-            throw new PropertyAccessException("Cannot update properties database, SQL ERROR", ex);
+            throw new PropertyAccessException(
+                    "Cannot update properties database, SQL ERROR", ex);
         } finally {
             closeConnection(conn, previousAutoCommit);
         }
@@ -199,7 +200,8 @@ public class JdbcPropertyStore extends AbstractPropertyStore {
         }
         catch (Exception ex) {
             rollback(conn);
-            throw new PropertyAccessException("Cannot delete property database, SQL ERROR", ex);
+            throw new PropertyAccessException(
+                    "Cannot delete property database, SQL ERROR", ex);
         } finally {
             closeConnection(conn, previousAutoCommit);
         }
@@ -308,11 +310,11 @@ public class JdbcPropertyStore extends AbstractPropertyStore {
         }
     }
 
-    private void deleteProperty(String name, Connection conn) throws SQLException {
+    private void deleteProperty(String name, Connection conn)
+            throws SQLException {
         Util.assertHasLength(name);
         PreparedStatement ps;
         try {
-            conn = getDataSource().getConnection();
             if (!existProperty(name, conn)) {
                 throw new PropertyNotFoundException(name);
             }
@@ -323,7 +325,8 @@ public class JdbcPropertyStore extends AbstractPropertyStore {
         }
     }
 
-    private <T> void createProperty(Property<T> prop, Connection conn) throws SQLException {
+    private <T> void createProperty(Property<T> prop, Connection conn)
+            throws SQLException {
         Util.assertNotNull(prop);
         PreparedStatement ps = null;
         try {
@@ -335,7 +338,8 @@ public class JdbcPropertyStore extends AbstractPropertyStore {
             ps.setString(2, prop.getType());
             ps.setString(3, prop.asString());
             ps.setString(4, prop.getDescription());
-            if (prop.getFixedValues() != null && !prop.getFixedValues().isEmpty()) {
+            if (prop.getFixedValues() != null
+                    && !prop.getFixedValues().isEmpty()) {
                 String fixedValues = prop.getFixedValues().toString();
                 ps.setString(5, fixedValues.substring(1, fixedValues.length() - 1));
             } else {

--- a/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
@@ -133,10 +133,10 @@ public class JdbcPropertyStore extends AbstractPropertyStore {
         } catch (PropertyAlreadyExistException ex) {
             rollback(conn);
             throw ex;
-        } catch (Exception ex) {
+        } catch (SQLException ex) {
             rollback(conn);
             throw new PropertyAccessException(
-                    "Cannot update properties database, SQL ERROR", ex);
+                    "Cannot create properties database, SQL ERROR", ex);
         } finally {
             closeConnection(conn, previousAutoCommit);
         }
@@ -205,10 +205,10 @@ public class JdbcPropertyStore extends AbstractPropertyStore {
             rollback(conn);
             throw ex;
         }
-        catch (Exception ex) {
+        catch (SQLException ex) {
             rollback(conn);
             throw new PropertyAccessException(
-                    "Cannot delete property database, SQL ERROR", ex);
+                    "Cannot Update property database, SQL ERROR", ex);
         } finally {
             closeConnection(conn, previousAutoCommit);
         }
@@ -228,7 +228,7 @@ public class JdbcPropertyStore extends AbstractPropertyStore {
         } catch (PropertyNotFoundException ex) {
             rollback(conn);
             throw ex;
-        }catch (Exception ex) {
+        }catch (SQLException ex) {
             rollback(conn);
             throw new PropertyAccessException(
                     "Cannot delete property database, SQL ERROR", ex);

--- a/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
@@ -20,12 +20,7 @@ package org.ff4j.property.store;
  * #L%
  */
 import static org.ff4j.store.JdbcStoreConstants.COL_PROPERTY_ID;
-import static org.ff4j.utils.JdbcUtils.buildStatement;
-import static org.ff4j.utils.JdbcUtils.closeConnection;
-import static org.ff4j.utils.JdbcUtils.closeResultSet;
-import static org.ff4j.utils.JdbcUtils.closeStatement;
-import static org.ff4j.utils.JdbcUtils.executeUpdate;
-import static org.ff4j.utils.JdbcUtils.isTableExist;
+import static org.ff4j.utils.JdbcUtils.*;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -120,31 +115,22 @@ public class JdbcPropertyStore extends AbstractPropertyStore {
     /** {@inheritDoc} */
     public <T> void createProperty(Property<T> ap) {
         Util.assertNotNull(ap);
-        Connection sqlConn = null;
-        PreparedStatement ps = null;
+        Connection conn = null;
+        Boolean previousAutoCommit = null;
         try {
-            sqlConn = getDataSource().getConnection();
-            if (existProperty(ap.getName())) {
-                throw new PropertyAlreadyExistException(ap.getName());
-            }
-            ps = sqlConn.prepareStatement(getQueryBuilder().createProperty());
-            ps.setString(1, ap.getName());
-            ps.setString(2, ap.getType());
-            ps.setString(3, ap.asString());
-            ps.setString(4, ap.getDescription());
-            if (ap.getFixedValues() != null && !ap.getFixedValues().isEmpty()) {
-                String fixedValues = ap.getFixedValues().toString();
-                ps.setString(5, fixedValues.substring(1, fixedValues.length() - 1));
-            } else {
-                ps.setString(5, null);
-            }
-            ps.executeUpdate();
-        } catch (SQLException sqlEX) {
-            throw new PropertyAccessException("Cannot update properties database, SQL ERROR", sqlEX);
+            conn = getDataSource().getConnection();
+            previousAutoCommit = conn.getAutoCommit();
+            conn.setAutoCommit(false);
+            createProperty(ap, conn);
+            conn.commit();
+        } catch (PropertyAlreadyExistException ex) {
+            rollback(conn);
+            throw ex;
+        } catch (Exception ex) {
+            rollback(conn);
+            throw new PropertyAccessException("Cannot update properties database, SQL ERROR", ex);
         } finally {
-            // Connection is closed alse here within clos statement
-            closeStatement(ps);
-            closeConnection(sqlConn);
+            closeConnection(conn, previousAutoCommit);
         }
     }
 
@@ -198,27 +184,46 @@ public class JdbcPropertyStore extends AbstractPropertyStore {
         if (prop == null || prop.getName() == null) {
             throw new IllegalArgumentException("Cannot update property, please provide property name");
         }
-        deleteProperty(prop.getName());
-        createProperty(prop);
+        Connection conn = null;
+        Boolean previousAutoCommit = null;
+        try {
+            conn = getDataSource().getConnection();
+            previousAutoCommit = conn.getAutoCommit();
+            conn.setAutoCommit(false);
+            deleteProperty(prop.getName(), conn);
+            createProperty(prop, conn);
+            conn.commit();
+        } catch (PropertyNotFoundException ex) {
+            rollback(conn);
+            throw ex;
+        }
+        catch (Exception ex) {
+            rollback(conn);
+            throw new PropertyAccessException("Cannot delete property database, SQL ERROR", ex);
+        } finally {
+            closeConnection(conn, previousAutoCommit);
+        }
     }
    
     /** {@inheritDoc} */
     public void deleteProperty(String name) {
         Util.assertHasLength(name);
-        Connection   sqlConn = null;
-        PreparedStatement ps = null;
+        Connection   conn = null;
+        Boolean previousAutoCommit = null;
         try {
-            sqlConn = getDataSource().getConnection();
-            if (!existProperty(name)) {
-                throw new PropertyNotFoundException(name);
-            }
-            ps = buildStatement(sqlConn, getQueryBuilder().deleteProperty(), name);
-            ps.executeUpdate();
-        } catch (SQLException sqlEX) {
-            throw new PropertyAccessException("Cannot delete property database, SQL ERROR", sqlEX);
+            conn = getDataSource().getConnection();
+            previousAutoCommit = conn.getAutoCommit();
+            conn.setAutoCommit(false);
+            deleteProperty(name, conn);
+            conn.commit();
+        } catch (PropertyNotFoundException ex) {
+            rollback(conn);
+            throw ex;
+        }catch (Exception ex) {
+            rollback(conn);
+            throw new PropertyAccessException("Cannot delete property database, SQL ERROR", ex);
         } finally {
-            closeStatement(ps);
-            closeConnection(sqlConn);
+            closeConnection(conn, previousAutoCommit);
         }
     }
     
@@ -283,6 +288,62 @@ public class JdbcPropertyStore extends AbstractPropertyStore {
         } finally {
             closeStatement(ps);
             closeConnection(sqlConn);
+        }
+    }
+
+    private boolean existProperty(String name, Connection conn) {
+        Util.assertHasLength(name);
+        PreparedStatement  ps = null;
+        ResultSet rs = null;
+        try {
+            ps = buildStatement(conn, getQueryBuilder().existProperty(), name);
+            rs = ps.executeQuery();
+            rs.next();
+            return 1 == rs.getInt(1);
+        } catch (SQLException sqlEX) {
+            throw new PropertyAccessException("Cannot check feature existence, error related to database", sqlEX);
+        } finally {
+            closeResultSet(rs);
+            closeStatement(ps);
+        }
+    }
+
+    private void deleteProperty(String name, Connection conn) throws SQLException {
+        Util.assertHasLength(name);
+        PreparedStatement ps;
+        try {
+            conn = getDataSource().getConnection();
+            if (!existProperty(name, conn)) {
+                throw new PropertyNotFoundException(name);
+            }
+            ps = buildStatement(conn, getQueryBuilder().deleteProperty(), name);
+            ps.executeUpdate();
+        } finally {
+            closeConnection(conn);
+        }
+    }
+
+    private <T> void createProperty(Property<T> prop, Connection conn) throws SQLException {
+        Util.assertNotNull(prop);
+        PreparedStatement ps = null;
+        try {
+            if (existProperty(prop.getName(), conn)) {
+                throw new PropertyAlreadyExistException(prop.getName());
+            }
+            ps = conn.prepareStatement(getQueryBuilder().createProperty());
+            ps.setString(1, prop.getName());
+            ps.setString(2, prop.getType());
+            ps.setString(3, prop.asString());
+            ps.setString(4, prop.getDescription());
+            if (prop.getFixedValues() != null && !prop.getFixedValues().isEmpty()) {
+                String fixedValues = prop.getFixedValues().toString();
+                ps.setString(5, fixedValues.substring(1, fixedValues.length() - 1));
+            } else {
+                ps.setString(5, null);
+            }
+            ps.executeUpdate();
+        } finally {
+            closeStatement(ps);
         }
     }
 

--- a/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
@@ -321,7 +321,7 @@ public class JdbcPropertyStore extends AbstractPropertyStore {
     private void deleteProperty(String name, Connection conn)
             throws SQLException {
         Util.assertHasLength(name);
-        PreparedStatement ps;
+        PreparedStatement ps = null;
         try {
             if (!existProperty(name, conn)) {
                 throw new PropertyNotFoundException(name);
@@ -329,7 +329,7 @@ public class JdbcPropertyStore extends AbstractPropertyStore {
             ps = buildStatement(conn, getQueryBuilder().deleteProperty(), name);
             ps.executeUpdate();
         } finally {
-            closeConnection(conn);
+            closeStatement(ps);
         }
     }
 


### PR DESCRIPTION
# Description

<!-- Description about this pull request -->
As described in https://github.com/ff4j/ff4j/issues/710, the create,update,delete operations on JdbcPropertyStore are now transactional, similar to JdbcFeatureStore

Closes : #710 

# Checklist for self review:

- [x] My code follows the [contribution guidelines](https://github.com/ff4j/ff4j/blob/main/CONTRIBUTING.md) of this project
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works-can't replicate the pooled data source in tests, but existing tests are passing
- [x] New and existing unit tests pass locally with my changes
- [x] My commits follow [conventional commit message guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
