### PR TITLE
Make EventPublisher rejection strategy configurable

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/audit/EventPublisher.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/EventPublisher.java
@@ -9,9 +9,9 @@ package org.ff4j.audit;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,16 +38,16 @@ import org.ff4j.audit.repository.InMemoryEventRepository;
  * @author Cedrick Lunven (@clunven)
  */
 public class EventPublisher {
-   
+
     /** DEFAULT. */
     public static final int DEFAULT_QUEUE_CAPACITY = 100;
-    
+
     /** DEFAULT. */
     public static final int DEFAULT_POOL_SIZE = 4;
-    
+
     /** 2s to save the event other wize skip. */
     public static final long timeout = 2000L;
-    
+
     /** Executor for item writer. */
     private ExecutorService executor;
 
@@ -66,14 +66,14 @@ public class EventPublisher {
     public EventPublisher() {
         this(DEFAULT_QUEUE_CAPACITY, DEFAULT_POOL_SIZE, new InMemoryEventRepository());
     }
-    
+
     /**
      * Default constructor.
      */
     public EventPublisher(EventRepository er) {
         this(DEFAULT_QUEUE_CAPACITY, DEFAULT_POOL_SIZE, er);
     }
-        
+
     /**
      * Default constructor.
      */
@@ -85,13 +85,39 @@ public class EventPublisher {
      * Default constructor.
      */
     public EventPublisher(int queueCapacity, int poolSize, EventRepository er, long submitTimeout) {
+        this(queueCapacity, poolSize, er, submitTimeout, new EventRejectedExecutionHandler());
+    }
+
+    /**
+     * Create an event publisher with a configurable rejection handler.
+     *
+     * @param queueCapacity queue capacity
+     * @param poolSize worker pool size
+     * @param er event repository
+     * @param rejectionHandler handler invoked when the executor is saturated
+     */
+    public EventPublisher(int queueCapacity, int poolSize, EventRepository er,
+                          RejectedExecutionHandler rejectionHandler) {
+        this(queueCapacity, poolSize, er, timeout, rejectionHandler);
+    }
+
+    /**
+     * Create an event publisher with configurable sizing, timeout and rejection handler.
+     *
+     * @param queueCapacity queue capacity
+     * @param poolSize worker pool size
+     * @param er event repository
+     * @param submitTimeout maximum time to wait for event publication
+     * @param rejectionHandler handler invoked when the executor is saturated
+     */
+    public EventPublisher(int queueCapacity, int poolSize, EventRepository er, long submitTimeout,
+                          RejectedExecutionHandler rejectionHandler) {
         // Initializing queue
         final BlockingQueue<Runnable> queue = new ArrayBlockingQueue<Runnable>(queueCapacity);
         // Executor with worker to process threads
-        RejectedExecutionHandler rej = new EventRejectedExecutionHandler();
         ThreadFactory tFactorty = new PublisherThreadFactory();
-        this.executor = 
-                new ThreadPoolExecutor(poolSize, poolSize, 0L, TimeUnit.MILLISECONDS, queue, tFactorty, rej);
+        this.executor =
+                new ThreadPoolExecutor(poolSize, poolSize, 0L, TimeUnit.MILLISECONDS, queue, tFactorty, rejectionHandler);
         // Override repository
         this.repository = er;
         this.submitTimeout = submitTimeout;
@@ -120,7 +146,7 @@ public class EventPublisher {
 
     /**
      * Publish event to repository
-     * 
+     *
      * @param e
      *            event.
      */
@@ -148,7 +174,7 @@ public class EventPublisher {
 
     /**
      * Setter accessor for attribute 'repository'.
-     * 
+     *
      * @param repository
      *            new value for 'repository '
      */
@@ -158,7 +184,7 @@ public class EventPublisher {
 
     /**
      * Getter accessor for attribute 'repository'.
-     * 
+     *
      * @return current value of 'repository'
      */
     public EventRepository getRepository() {

--- a/ff4j-core/src/main/java/org/ff4j/audit/EventRejectedExecutionHandler.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/EventRejectedExecutionHandler.java
@@ -20,7 +20,7 @@ package org.ff4j.audit;
  * #L%
  */
 
-
+import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -30,20 +30,106 @@ import java.util.concurrent.ThreadPoolExecutor;
  * @author Cedrick Lunven (@clunven)</a>
  */
 public class EventRejectedExecutionHandler implements RejectedExecutionHandler {
+
+    /** Default delay between retries. */
+    public static final long DEFAULT_RETRY_DELAY = 1000L;
+
+    /** Default maximum retries for the bounded strategy. */
+    public static final int DEFAULT_MAX_RETRIES = 3;
+
+    /** Available strategies when the event publisher executor is saturated. */
+    public enum RejectionStrategy {
+        /** Retry until the task can be queued. */
+        RETRY_UNBOUNDED,
+        /** Retry up to the configured maximum. */
+        RETRY_BOUNDED,
+        /** Cancel the rejected task immediately. */
+        DISCARD
+    }
+
+    /** Rejection strategy. */
+    private final RejectionStrategy strategy;
+
+    /** Maximum retries for the bounded strategy. */
+    private final int maxRetries;
+
+    /** Delay between retries. */
+    private final long retryDelay;
  
     /** Simulate Interrupted. */
     private static boolean mock = false;
+
+    /** Create a handler with the legacy unbounded retry behavior. */
+    public EventRejectedExecutionHandler() {
+        this(RejectionStrategy.RETRY_UNBOUNDED, 0, DEFAULT_RETRY_DELAY);
+    }
+
+    /**
+     * Create a handler with default retry settings.
+     *
+     * @param strategy rejection strategy
+     */
+    public EventRejectedExecutionHandler(RejectionStrategy strategy) {
+        this(strategy, DEFAULT_MAX_RETRIES, DEFAULT_RETRY_DELAY);
+    }
+
+    /**
+     * Create a configurable rejection handler.
+     *
+     * @param strategy rejection strategy
+     * @param maxRetries maximum retries for {@link RejectionStrategy#RETRY_BOUNDED}
+     * @param retryDelay delay in milliseconds between retries
+     */
+    public EventRejectedExecutionHandler(RejectionStrategy strategy, int maxRetries, long retryDelay) {
+        if (strategy == null) {
+            throw new IllegalArgumentException("Rejection strategy cannot be null");
+        }
+        if (maxRetries < 0) {
+            throw new IllegalArgumentException("Maximum retries cannot be negative");
+        }
+        if (retryDelay < 0) {
+            throw new IllegalArgumentException("Retry delay cannot be negative");
+        }
+        this.strategy = strategy;
+        this.maxRetries = maxRetries;
+        this.retryDelay = retryDelay;
+    }
     
     /** {@inheritDoc} */
     @Override
     public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
-        try {
-            this.waitInSeconds(1);
-            // try once again
-            executor.execute(r);
-        } catch (InterruptedException e) {
-            // Trace error
-            System.err.println("Cannot send Audit Event");
+        if (strategy == RejectionStrategy.DISCARD) {
+            cancel(r);
+            return;
+        }
+
+        int retryCount = 0;
+        while (strategy == RejectionStrategy.RETRY_UNBOUNDED || retryCount < maxRetries) {
+            try {
+                waitInMillis(retryDelay);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                cancel(r);
+                return;
+            }
+            if (executor.isShutdown()) {
+                cancel(r);
+                return;
+            }
+            if (executor.getQueue().offer(r)) {
+                if (executor.isShutdown() && executor.remove(r)) {
+                    cancel(r);
+                }
+                return;
+            }
+            retryCount++;
+        }
+        cancel(r);
+    }
+
+    private void cancel(Runnable runnable) {
+        if (runnable instanceof Future<?>) {
+            ((Future<?>) runnable).cancel(false);
         }
     }
     
@@ -56,8 +142,18 @@ public class EventRejectedExecutionHandler implements RejectedExecutionHandler {
      *      interupted
      */
     public void waitInSeconds(int nbSecond) throws InterruptedException {
+        waitInMillis(1000L * nbSecond);
+    }
+
+    /**
+     * Wait between retries.
+     *
+     * @param milliseconds number of milliseconds to wait
+     * @throws InterruptedException interrupted
+     */
+    public void waitInMillis(long milliseconds) throws InterruptedException {
         if (mock) throw new InterruptedException();
-        Thread.sleep(1000 * nbSecond);
+        Thread.sleep(milliseconds);
     }
 
     public static boolean isMock() {

--- a/ff4j-core/src/test/java/org/ff4j/test/audit/EventRejectedExecutionHandlerTest.java
+++ b/ff4j-core/src/test/java/org/ff4j/test/audit/EventRejectedExecutionHandlerTest.java
@@ -1,0 +1,164 @@
+package org.ff4j.test.audit;
+
+/*-
+ * #%L
+ * ff4j-core
+ * %%
+ * Copyright (C) 2013 - 2024 FF4J
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import static org.ff4j.audit.EventRejectedExecutionHandler.RejectionStrategy.DISCARD;
+import static org.ff4j.audit.EventRejectedExecutionHandler.RejectionStrategy.RETRY_BOUNDED;
+import static org.ff4j.audit.EventRejectedExecutionHandler.RejectionStrategy.RETRY_UNBOUNDED;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.ff4j.audit.EventRejectedExecutionHandler;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class EventRejectedExecutionHandlerTest {
+
+    @Test
+    public void discardCancelsRejectedTask() {
+        FutureTask<Boolean> task = new FutureTask<Boolean>(() -> true);
+        EventRejectedExecutionHandler handler = new EventRejectedExecutionHandler(DISCARD);
+
+        handler.rejectedExecution(task, null);
+
+        Assertions.assertTrue(task.isCancelled());
+    }
+
+    @Test
+    public void boundedRetryCancelsTaskAfterMaximumRetries() {
+        ThreadPoolExecutor executor = newExecutor();
+        executor.getQueue().offer(new FutureTask<Boolean>(() -> true));
+        CountingHandler handler = new CountingHandler(RETRY_BOUNDED, 3);
+        FutureTask<Boolean> rejectedTask = new FutureTask<Boolean>(() -> true);
+
+        handler.rejectedExecution(rejectedTask, executor);
+
+        Assertions.assertEquals(3, handler.getRetryCount());
+        Assertions.assertTrue(rejectedTask.isCancelled());
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void unboundedRetryQueuesTaskWhenCapacityBecomesAvailable() {
+        ThreadPoolExecutor executor = newExecutor();
+        executor.getQueue().offer(new FutureTask<Boolean>(() -> true));
+        QueueReleasingHandler handler = new QueueReleasingHandler();
+        FutureTask<Boolean> rejectedTask = new FutureTask<Boolean>(() -> true);
+
+        handler.rejectedExecution(rejectedTask, executor);
+
+        Assertions.assertEquals(2, handler.getRetryCount());
+        Assertions.assertFalse(rejectedTask.isCancelled());
+        Assertions.assertTrue(executor.getQueue().contains(rejectedTask));
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void constructorRejectsInvalidRetrySettings() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new EventRejectedExecutionHandler(null, 1, 1L));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new EventRejectedExecutionHandler(RETRY_BOUNDED, -1, 1L));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new EventRejectedExecutionHandler(RETRY_BOUNDED, 1, -1L));
+    }
+
+    @Test
+    public void interruptedRetryCancelsTaskAndRestoresInterrupt() {
+        ThreadPoolExecutor executor = newExecutor();
+        executor.getQueue().offer(new FutureTask<Boolean>(() -> true));
+        EventRejectedExecutionHandler handler = new EventRejectedExecutionHandler(RETRY_UNBOUNDED, 0, 1L);
+        FutureTask<Boolean> rejectedTask = new FutureTask<Boolean>(() -> true);
+        Thread.currentThread().interrupt();
+
+        try {
+            handler.rejectedExecution(rejectedTask, executor);
+
+            Assertions.assertTrue(Thread.currentThread().isInterrupted());
+            Assertions.assertTrue(rejectedTask.isCancelled());
+        } finally {
+            Thread.interrupted();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void stoppedExecutorCancelsTaskWithoutRetrying() {
+        ThreadPoolExecutor executor = newExecutor();
+        executor.shutdownNow();
+        CountingHandler handler = new CountingHandler(RETRY_UNBOUNDED, 0);
+        FutureTask<Boolean> rejectedTask = new FutureTask<Boolean>(() -> true);
+
+        handler.rejectedExecution(rejectedTask, executor);
+
+        Assertions.assertEquals(1, handler.getRetryCount());
+        Assertions.assertTrue(rejectedTask.isCancelled());
+    }
+
+    private ThreadPoolExecutor newExecutor() {
+        return new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<Runnable>(1));
+    }
+
+    private static class CountingHandler extends EventRejectedExecutionHandler {
+
+        private int retryCount;
+
+        CountingHandler(RejectionStrategy strategy, int maxRetries) {
+            super(strategy, maxRetries, 0L);
+        }
+
+        @Override
+        public void waitInMillis(long milliseconds) {
+            retryCount++;
+        }
+
+        int getRetryCount() {
+            return retryCount;
+        }
+    }
+
+    private static class QueueReleasingHandler extends CountingHandler {
+
+        QueueReleasingHandler() {
+            super(RETRY_UNBOUNDED, 0);
+        }
+
+        @Override
+        public void waitInMillis(long milliseconds) {
+            super.waitInMillis(milliseconds);
+            if (getRetryCount() == 2) {
+                // Capacity becomes available while the handler is retrying.
+                executor.getQueue().poll();
+            }
+        }
+
+        private ThreadPoolExecutor executor;
+
+        @Override
+        public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+            this.executor = executor;
+            super.rejectedExecution(r, executor);
+        }
+    }
+}

--- a/ff4j-core/src/test/java/org/ff4j/test/audit/EventWorkerTest.java
+++ b/ff4j-core/src/test/java/org/ff4j/test/audit/EventWorkerTest.java
@@ -9,9 +9,9 @@ package org.ff4j.test.audit;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,6 +29,10 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.ff4j.audit.Event;
 import org.ff4j.audit.EventPublisher;
 import org.ff4j.audit.EventRejectedExecutionHandler;
@@ -39,7 +43,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class EventWorkerTest {
-    
+
     @Test
     public void testEventWorker() {
         // Given
@@ -51,7 +55,7 @@ public class EventWorkerTest {
         // Then
         Assertions.assertEquals("NAME1", ew.getName());
     }
-    
+
     @Test
     public void testEventWorkerCall() throws Exception {
         // Given
@@ -62,7 +66,7 @@ public class EventWorkerTest {
         // When
         ew.call();
     }
-    
+
     @Test
     public void testErrorOnSubmitEventPublisher() {
         // Given
@@ -73,10 +77,45 @@ public class EventWorkerTest {
         evtPublisher.publish(evt);
         Assertions.assertNotNull(evt);
     }
-    
+
     @Test
     public void testEventRejected() {
         Assertions.assertFalse(EventRejectedExecutionHandler.isMock());
+    }
+
+    @Test
+    public void configuredDiscardStrategyHandlesPublisherSaturation() throws Exception {
+        CountDownLatch repositoryBlocked = new CountDownLatch(1);
+        CountDownLatch releaseRepository = new CountDownLatch(1);
+        EventRepository repository = mock(EventRepository.class);
+        when(repository.saveEvent(org.mockito.ArgumentMatchers.any(Event.class))).thenAnswer(invocation -> {
+            repositoryBlocked.countDown();
+            releaseRepository.await();
+            return true;
+        });
+        AtomicInteger rejectedTasks = new AtomicInteger();
+        EventRejectedExecutionHandler handler = new EventRejectedExecutionHandler(
+                EventRejectedExecutionHandler.RejectionStrategy.DISCARD) {
+            @Override
+            public void rejectedExecution(Runnable runnable, java.util.concurrent.ThreadPoolExecutor executor) {
+                rejectedTasks.incrementAndGet();
+                super.rejectedExecution(runnable, executor);
+            }
+        };
+        EventPublisher publisher = new EventPublisher(1, 1, repository, 0L, handler);
+
+        try {
+            publisher.publish(new Event(SOURCE_JAVA, TARGET_FEATURE, "F1", ACTION_CHECK_OK));
+            Assertions.assertTrue(repositoryBlocked.await(1, TimeUnit.SECONDS));
+            publisher.publish(new Event(SOURCE_JAVA, TARGET_FEATURE, "F2", ACTION_CHECK_OK));
+
+            publisher.publish(new Event(SOURCE_JAVA, TARGET_FEATURE, "F3", ACTION_CHECK_OK));
+
+            Assertions.assertEquals(1, rejectedTasks.get());
+        } finally {
+            releaseRepository.countDown();
+            publisher.stop();
+        }
     }
 
 }


### PR DESCRIPTION
# Description

Makes the `EventPublisher` rejection behavior configurable while preserving the current unbounded retry strategy as the default for backward compatibility.

The change adds:

- `RETRY_UNBOUNDED`, `RETRY_BOUNDED`, and `DISCARD` strategies.
- Configurable maximum retries and retry delay for bounded retries.
- Iterative retries to avoid recursive executor submissions.
- Cancellation of discarded `Future` tasks so callers do not wait for the publisher timeout.
- `EventPublisher` constructors accepting a custom `RejectedExecutionHandler`.
- Saturation, interruption, shutdown, and invalid configuration tests.

Closes #774

# Checklist for self review:

- [x] My code follows the [contribution guidelines](https://github.com/ff4j/ff4j/blob/main/CONTRIBUTING.md) of this project
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My commits follow [conventional commit message guidelines](https://www.conventionalcommits.org/en/v1.0.0/)